### PR TITLE
Create a resource fetch system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1040,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1257,6 +1283,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "7.0.0-rc2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a1e35a65fe0538a60167f0ada6e195ad5d477f6ddae273943596d4a1a5730b"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "equivalent",
+ "hashbrown 0.15.5",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,6 +1508,12 @@ checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2446,13 +2492,17 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
+ "bytes",
  "cairo-rs 0.21.1",
+ "chrono",
  "console-subscriber",
+ "dashmap",
  "eframe",
  "egui",
  "env_logger",
  "fontique",
  "futures",
+ "futures-core",
  "futures-intrusive",
  "futures-util",
  "gdk4 0.8.2",
@@ -2461,9 +2511,13 @@ dependencies = [
  "gtk4",
  "hashbrown 0.15.5",
  "http",
+ "indicatif",
  "lazy_static",
  "log",
+ "mime",
  "num_cpus",
+ "once_cell",
+ "parking_lot",
  "parley",
  "png",
  "pollster",
@@ -2480,7 +2534,9 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tracing",
  "tui-input",
  "url",
  "uuid",
@@ -2903,6 +2959,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3067,6 +3147,19 @@ checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width 0.2.0",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -5574,6 +5667,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5882,6 +5976,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "untrusted"
@@ -6463,12 +6563,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-registry"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
 ]
@@ -6488,7 +6594,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6507,7 +6613,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6544,6 +6650,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -6598,7 +6713,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1.47", features = [
     "rt-multi-thread",
     "full",
     "tracing",
+    "io-util",
 ] }
 thiserror = "1.0.69"
 rand = "0.9.2"
@@ -74,12 +75,22 @@ hashbrown = "0.15.5"
 skrifa = "0.31.3"
 num_cpus = "1.17.0"
 time = "0.3.41"
-tokio-util = "0.7.16"
+tokio-util = {  version = "0.7.16", features=["io"] }
 tempfile = "3.21.0"
 console-subscriber = "0.4.1"
 tui-input = "0.14.0"
 bitflags = "1.3.2"
 futures-util = "0.3.31"
+bytes = "1.10.1"
+dashmap = "7.0.0-rc2"
+tracing = "0.1.41"
+once_cell = "1.21.3"
+parking_lot = "0.12.4"
+indicatif = "0.18.0"
+tokio-stream = { version = "0.1.17", features = ["sync"] }
+futures-core = "0.3.31"
+mime = "0.3.17"
+chrono = "0.4.42"
 
 [features]
 default = ["sqlite_cookie_store", "parley_layout"]

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,20 +1,15 @@
-use gosub_engine::{
-    cookies::DefaultCookieJar,
-    events::EngineEvent,
-    render::Viewport,
-    storage::{InMemoryLocalStore, InMemorySessionStore, PartitionPolicy, StorageService},
-    zone::ZoneConfig,
-    zone::ZoneServices,
-    EngineConfig, EngineError, GosubEngine,
-};
-
 use gosub_engine::events::{LoadEvent, MouseButton, NavigationEvent, ResourceEvent, TabCommand};
-use gosub_engine::storage::PartitionKey;
-use gosub_engine::tab::{TabCacheMode, TabCookieJar, TabDefaults, TabOverrides, TabStorageScope};
+use gosub_engine::tab::TabDefaults;
+use gosub_engine::{cookies::DefaultCookieJar, events::EngineEvent, render::Viewport, storage::{InMemoryLocalStore, InMemorySessionStore, PartitionPolicy, StorageService}, zone::ZoneConfig, zone::ZoneServices, EngineConfig, EngineError, GosubEngine, NavigationId, Action};
 use std::sync::Arc;
+use std::time::Duration;
+use http::header;
+use tokio::sync::mpsc;
+use gosub_engine::net::types::FetchResultMeta;
 
 #[tokio::main]
 async fn main() -> Result<(), EngineError> {
+    // Allow debugging with tokio-console
     console_subscriber::init();
 
     // Configure the engine through the engine config builder. This will set up the main runtime
@@ -85,7 +80,7 @@ async fn main() -> Result<(), EngineError> {
 
     // Navigate somewhere
     tab.send(TabCommand::Navigate {
-        url: "https://gosub.io".into(),
+        url: "https://news.ycombinator.com".into(),
     })
     .await?;
 
@@ -110,59 +105,36 @@ async fn main() -> Result<(), EngineError> {
     zone.set_description("This is the new description");
     zone.set_color([255, 128, 64, 255]);
 
-    // Open a private tab inside the zone. Note that we override some of the tab options to
-    // make it private (ephemeral storage, cookie jar, cache, etc). We also set an initial URL that
-    // is automatically loaded when the tab is created.
-    let def_values = TabDefaults {
-        url: None,
-        title: Some("New Private Tab".into()),
-        viewport: Some(Viewport::new(0, 0, 800, 600)),
-    };
-
-    let _private_tab_handle = zone
-        .create_tab(
-            def_values,
-            Some(TabOverrides {
-                partition_key: Some(PartitionKey::random()),
-                cookie_jar: TabCookieJar::Ephemeral,
-                storage_scope: TabStorageScope::Ephemeral,
-                cache_mode: TabCacheMode::Ephemeral,
-                persist_history: Some(false),
-                persist_downloads: Some(false),
-                ..Default::default()
-            }),
-        )
-        .await
-        .expect("cannot create tab");
-
-    // let autoexec_handle = tokio::spawn(async move {
-    //     _ = private_tab_handle.send(TabCommand::ResumeDrawing { fps: 5 }).await;
-    //     sleep(Duration::from_secs(5)).await;
-    //     _ = private_tab_handle.send(TabCommand::SuspendDrawing).await;
-    //     sleep(Duration::from_secs(5)).await;
-    //     _ = private_tab_handle.send(TabCommand::ResumeDrawing { fps: 60 }).await;
-    //     sleep(Duration::from_secs(1)).await;
-    //     _ = private_tab_handle.send(TabCommand::SuspendDrawing).await;
-    // });
-
     // This is the application's main loop, where we receive events from the engine and
     // act on them. In a real application, you would probably want to run this in
     // a separate task/thread, and not block the main thread.
 
     let mut seen_intervals = 0usize;
     let mut seen_frames = 0usize;
-    let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+    let mut interval = tokio::time::interval(Duration::from_secs(1));
+    let tab_clone = tab.clone();
 
     loop {
         tokio::select! {
             Ok(ev) = event_rx.recv() => {
                 // println!("Received event: {:?}", ev);
 
+                // If we find a response meta event, we need to decide how to handle the response (saving / download, engine rendering etc.)
+                if let EngineEvent::NavigationResponse { tab_id, nav_id, meta } = ev {
+                    println!("[event][meta] ResponseMeta found: {tab_id} {nav_id} {meta:?}");
+                    // Normally, we should check if the tab_id we get actually matches one of our tabs.
+                    if tab_clone.tab_id == tab_id {
+                        on_response_meta(nav_id, meta, tab_clone.cmd_tx.clone()).await;
+                    }
+                    continue;
+                }
+
                 // Just count the frames we see for now
                 if matches!(ev, EngineEvent::Redraw { .. }) {
                     seen_frames += 1;
                     println!("Total frames seen so far: {seen_frames}");
                 }
+
                 handle_event(ev);
             }
             _ = tokio::signal::ctrl_c() => {
@@ -173,16 +145,13 @@ async fn main() -> Result<(), EngineError> {
                 println!("Ticking the UA interval");
 
                 seen_intervals += 1;
-                if seen_intervals >= 10 {
+                if seen_intervals >= 1000 {
                     println!("Seen {seen_intervals} intervals, exiting main loop");
                     break;
                 }
             }
         }
     }
-
-    // Wait until our commands are done
-    // autoexec_handle.await;
 
     println!("Shutting down engine...");
     engine.shutdown().await?;
@@ -198,75 +167,175 @@ async fn main() -> Result<(), EngineError> {
     Ok(())
 }
 
+async fn on_response_meta(nav_id: NavigationId, meta: FetchResultMeta, cmd_tx: mpsc::Sender<TabCommand>) {
+    let choice = if let Some(disp) = meta.headers.get(http::header::CONTENT_DISPOSITION) {
+        let s = disp.to_str().unwrap_or_default().to_ascii_lowercase();
+        if s.contains("attachment") {
+            Action::Download {
+                dest: std::path::PathBuf::from("/tmp/downloaded.bin"),
+            }
+        } else {
+            Action::Render
+        }
+    } else if meta.headers.get(header::CONTENT_TYPE).unwrap() == "text/html" {
+        Action::Render
+    } else {
+        Action::Download {
+            dest: std::path::PathBuf::from("/tmp/downloaded.bin"),
+        }
+    };
+
+    // Send back to the engine what we like to do with this navigation
+    let _ = cmd_tx
+        .send(TabCommand::NavigateDecision {
+            nav_id,
+            choice,
+        })
+        .await;
+}
+
 fn handle_event(ev: EngineEvent) {
     match ev {
         EngineEvent::TabCreated { tab_id, .. } => {
             // let tab = self.tabs.get(&tab_id).expect("Unknown tab");
             println!("[event] TabCreated: {tab_id:?}");
         }
-        EngineEvent::Load { tab_id, event} => {
-            match event {
-                LoadEvent::Started { .. } => {
-                    println!("[event][load] Started: {tab_id}");
-                }
-                LoadEvent::Finished { .. } => {
-                    println!("[event][load] Finished: {tab_id}");
-                }
-                LoadEvent::Failed { .. } => {
-                    println!("[event][load] Failed: {tab_id}");
-                }
-                LoadEvent::Cancelled { .. } => {
-                    println!("[event][load] Cancelled: {tab_id}");
-                }
+        EngineEvent::Load { tab_id, event } => match event {
+            LoadEvent::Started { .. } => {
+                println!("[event][load] Started: {tab_id}");
             }
-        }
-        EngineEvent::Navigation { tab_id, event} => {
-            match event {
-                NavigationEvent::Started { nav_id, url } => {
-                    println!("[event] NavigationStarted:\n     TabId: {tab_id}\n     NavId: {nav_id}\n     Url: {url}");
-                }
-                NavigationEvent::Committed { nav_id, url } => {
-                    println!("[event] NavigationCommitted:\n     TabId: {tab_id}\n     NavId: {nav_id}\n     Url: {url}");
-                }
-                NavigationEvent::Finished { nav_id, url } => {
-                    println!("[event] NavigationFinished:\n     TabId: {tab_id}\n     NavId: {nav_id}\n     Url: {url}");
-                }
-                NavigationEvent::Failed { nav_id, url, error } => {
-                    let nav_id = match nav_id {
-                        Some(nav_id) => nav_id.to_string(),
-                        None => "".into(),
-                    };
+            LoadEvent::Finished { .. } => {
+                println!("[event][load] Finished: {tab_id}");
+            }
+            LoadEvent::Failed { .. } => {
+                println!("[event][load] Failed: {tab_id}");
+            }
+            LoadEvent::Cancelled { .. } => {
+                println!("[event][load] Cancelled: {tab_id}");
+            }
+            LoadEvent::Progress {
+                finished,
+                bytes_received,
+                ttfb,
+                elapsed,
+                ..
+            } => {
+                println!("[event][load] Progress: {tab_id}: {bytes_received} bytes TTFB: {ttfb} Fin: {finished} Elapsed: {}us", elapsed.as_micros());
+            }
+        },
+        EngineEvent::Navigation { tab_id, event } => match event {
+            NavigationEvent::Started { nav_id, url } => {
+                println!("[event] NavigationStarted:\n     TabId: {tab_id}\n     NavId: {nav_id}\n     Url: {url}");
+            }
+            NavigationEvent::Committed { nav_id, url } => {
+                println!("[event] NavigationCommitted:\n     TabId: {tab_id}\n     NavId: {nav_id}\n     Url: {url}");
+            }
+            NavigationEvent::Finished { nav_id, url } => {
+                println!("[event] NavigationFinished:\n     TabId: {tab_id}\n     NavId: {nav_id}\n     Url: {url}");
+            }
+            NavigationEvent::Failed { nav_id, url, error } => {
+                let nav_id = match nav_id {
+                    Some(nav_id) => nav_id.to_string(),
+                    None => "".into(),
+                };
 
-                    println!("[event] NavigationFailed:\n     TabId: {tab_id}\n     NavId: {nav_id}\n     Url: {url}\n     Error: {error}");
-                }
-                NavigationEvent::Cancelled { nav_id, url, reason } => {
-                    println!("[event] NavigationCancelled:\n     TabId: {tab_id}\n     NavId: {nav_id}\n     Url: {url}\n     Reason: {reason:?}");
+                println!("[event] NavigationFailed:\n     TabId: {tab_id}\n     NavId: {nav_id}\n     Url: {url}\n     Error: {error}");
+            }
+            NavigationEvent::Cancelled { nav_id, url, reason } => {
+                println!("[event] NavigationCancelled:\n     TabId: {tab_id}\n     NavId: {nav_id}\n     Url: {url}\n     Reason: {reason:?}");
+            }
+
+            NavigationEvent::Progress { nav_id, received_bytes, expected_length, elapsed } => {
+                println!("[event] NavigationProgress:\n     TabId: {tab_id}\n     NavId: {nav_id}\n     Received Bytes: {received_bytes}\n     Expected Length: {expected_length:?}\n     Elapsed: {elapsed:?}");
+            }
+            NavigationEvent::FailedUrl { nav_id, url, error } => {
+                println!("[event] NavigationFailedUrl:\n     TabId: {tab_id}\n     NavId: {nav_id:?}\n     Url: {url}\n     Error: {error:?}");
+            }
+        },
+        EngineEvent::Resource { tab_id, event } => match event {
+            ResourceEvent::Queued {
+                nav_id,
+                url,
+                kind,
+                initiator,
+                priority,
+            } => {
+                println!("[event] ResourceQueued:\n     TabId: {tab_id}\n     NavId: {nav_id}\n     Url: {url}\n     Kind: {kind:?}\n     Initator: {initiator:?}\n     Priority: {priority}");
+            }
+            ResourceEvent::Started {
+                nav_id,
+                req_id,
+                url,
+                kind,
+                initiator,
+            } => {
+                println!("[event] ResourceStarted:\n     TabId: {tab_id}\n     ReqId: {req_id}\n     NavId: {nav_id}\n     Url: {url}\n     Kind: {kind:?}\n     Initator: {initiator:?}");
+            }
+            ResourceEvent::Redirected {
+                nav_id,
+                req_id,
+                from,
+                to,
+                status,
+            } => {
+                println!("[event] ResourceRedirected:\n     TabId: {tab_id}\n     ReqId: {req_id}\n     NavId: {nav_id}\n     From: {from}\n     To: {to}\n     Status: {status}");
+            }
+            ResourceEvent::Progress {
+                nav_id,
+                req_id,
+                received_bytes,
+                expected_length,
+                elapsed,
+            } => {
+                let el = expected_length.unwrap_or(0);
+                println!("[event] ResourceProgress: \n     TabId: {tab_id}\n     ReqId: {req_id}\n     NavId: {nav_id}\n     Received Bytes: {received_bytes}\n     Expected Length: {el}\n     Elapsed: {elapsed:?}");
+            }
+            ResourceEvent::Finished {
+                nav_id,
+                req_id,
+                url,
+                received_bytes,
+                elapsed
+            } => {
+                // let content_type = content_type.unwrap_or_default();
+                println!("[event] ResourceFinished:\n     TabId: {tab_id}\n     ReqId: {req_id}\n     NavId: {nav_id}\n     Url: {url}\n     Elapsed: {elapsed:?}\n     Received: {received_bytes}");
+            }
+            ResourceEvent::Failed {
+                nav_id,
+                req_id,
+                url,
+                error,
+            } => {
+                println!("[event] ResourceFailed:\n     TabId: {tab_id}\n     ReqId: {req_id}\n     NavId: {nav_id}\n     Url: {url}\n     Error: {error}");
+            }
+            ResourceEvent::Cancelled {
+                nav_id,
+                req_id,
+                url,
+                reason,
+            } => {
+                println!("[event] ResourceCancelled:\n     TabId: {tab_id}\n     ReqId: {req_id}\n     NavId: {nav_id}\n     Url: {url}\n     Reason: {reason:?}");
+            }
+            ResourceEvent::Headers {
+                nav_id,
+                req_id,
+                url,
+                status,
+                content_length,
+                content_type,
+                headers,
+            } => {
+                let content_type = content_type.unwrap_or_default();
+                let content_length = match content_length {
+                    Some(len) => len.to_string(),
+                    None => "unknown".into(),
+                };
+                println!("[event] ResourceHeaders:\n     TabId: {tab_id}\n     ReqId: {req_id}\n     NavId: {nav_id}\n     Url: {url}\n     Status: {status}\n     Content-Length: {content_length}\n     Content-Type: {content_type}\n     Headers:\n");
+                for (k, v) in headers {
+                    println!("         {k}: {v}");
                 }
             }
-        }
-        EngineEvent::Resource { tab_id, event } => {
-            match event {
-                ResourceEvent::Started { nav_id, req_id, url, kind, initiator, priority } => {
-                    println!("[event] ResourceStarted:\n     TabId: {tab_id}\n     ReqId: {req_id}\n     NavId: {nav_id}\n     Url: {url}\n     Kind: {kind:?}\n     Initator: {initiator:?}\n     Priority: {priority}");
-                }
-                ResourceEvent::Redirected { nav_id, req_id, from, to, status } => {
-                    println!("[event] ResourceRedirected:\n     TabId: {tab_id}\n     ReqId: {req_id}\n     NavId: {nav_id}\n     From: {from}\n     To: {to}\n     Status: {status}");
-                }
-                ResourceEvent::Progress { nav_id, req_id, received_bytes } => {
-                    println!("[event] ResourceProgress: \n     TabId: {tab_id}\n     ReqId: {req_id}\n     NavId: {nav_id}\n     Received Bytes: {received_bytes}");
-                }
-                ResourceEvent::Finished { nav_id, req_id, url, bytes, content_type, elapsed } => {
-                    let content_type = content_type.unwrap_or_default();
-                    println!("[event] ResourceFinished:\n     TabId: {tab_id}\n     ReqId: {req_id}\n     NavId: {nav_id}\n     Url: {url}\n     Bytes: {bytes}\n     Content-Type: {content_type}\n     Elapsed: {elapsed:?}");
-                }
-                ResourceEvent::Failed { nav_id, req_id, url, error } => {
-                    println!("[event] ResourceFailed:\n     TabId: {tab_id}\n     ReqId: {req_id}\n     NavId: {nav_id}\n     Url: {url}\n     Error: {error}");
-                }
-                ResourceEvent::Cancelled { nav_id, req_id, url, reason } => {
-                    println!("[event] ResourceCancelled:\n     TabId: {tab_id}\n     ReqId: {req_id}\n     NavId: {nav_id}\n     Url: {url}\n     Reason: {reason:?}");
-                }
-            }
-        }
+        },
         EngineEvent::Redraw { tab_id, .. } => {
             // With a real backend, you might get a handle/texture to present here.
             println!("[event] FrameReady for tab={tab_id:?}");

--- a/examples/multi_tab.rs
+++ b/examples/multi_tab.rs
@@ -1,0 +1,297 @@
+use gosub_engine::{
+    cookies::DefaultCookieJar,
+    events::EngineEvent,
+    render::Viewport,
+    storage::{InMemoryLocalStore, InMemorySessionStore, PartitionPolicy, StorageService},
+    zone::ZoneConfig,
+    zone::ZoneServices,
+    EngineConfig, EngineError, GosubEngine,
+};
+
+use gosub_engine::events::{LoadEvent, NavigationEvent, ResourceEvent};
+use gosub_engine::tab::{TabDefaults, TabId};
+use std::sync::Arc;
+use std::time::Duration;
+use rand::rng;
+use rand::prelude::IndexedRandom;
+use tokio::time::sleep;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::fmt::Write as _;
+
+static UI: Lazy<Mutex<Ui>> = Lazy::new(|| Mutex::new(Ui::new()));
+
+
+struct Ui {
+    mp: MultiProgress,
+    bars: HashMap<TabId, ProgressBar>,
+}
+
+impl Ui {
+    fn new() -> Self {
+        Self { mp: MultiProgress::new(), bars: HashMap::new() }
+    }
+
+    fn bar_for(&mut self, tab: TabId) -> ProgressBar {
+        use std::collections::hash_map::Entry;
+        match self.bars.entry(tab) {
+            Entry::Occupied(e) => e.get().clone(),
+            Entry::Vacant(v) => {
+                let pb = self.mp.add(ProgressBar::new_spinner());
+                pb.enable_steady_tick(std::time::Duration::from_millis(120));
+                pb.set_style(
+                    ProgressStyle::with_template("[{prefix:.dim}] {wide_msg}")
+                        .unwrap()
+                        .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ "),
+                );
+                pb.set_prefix(format!("{tab}"));
+                v.insert(pb.clone());
+                pb
+            }
+        }
+    }
+
+    fn update(&mut self, tab: TabId, msg: impl Into<String>) {
+        self.bar_for(tab).set_message(msg.into());
+    }
+
+    fn done(&mut self, tab: TabId) {
+        if let Some(pb) = self.bars.remove(&tab) {
+            pb.finish_and_clear();
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), EngineError> {
+    console_subscriber::init();
+
+    // Configure the engine through the engine config builder. This will set up the main runtime
+    // configuration of the engine. It's possible for some values to be changed at runtime, but
+    // not all of them
+    let engine_cfg = EngineConfig::builder()
+        .max_zones(5)
+        .build()
+        .expect("Configuration is not valid");
+
+    // Set up a render backend. In this example we use the NullBackend which does not render
+    // anything.
+    let backend = gosub_engine::render::backends::null::NullBackend::new().expect("null backend");
+
+    // Instantiate and start the engine
+    let mut engine = GosubEngine::new(Some(engine_cfg), Box::new(backend));
+    let engine_join_handle = engine.start().expect("cannot start engine");
+
+    // Get our event channel to receive events from the engine. Note that you will only receive events
+    // send from this point on.
+    let mut event_rx = engine.subscribe_events();
+
+    // Configure a zone. This works the same way as the engine config, using a builder
+    // pattern to set up the configuration before building it.
+    let zone_cfg = ZoneConfig::builder()
+        .max_tabs(100)
+        .do_not_track(true)
+        .accept_languages("fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5")
+        .build()
+        .expect("ZoneConfig is not valid");
+
+    // Create the services for this zone. These services are automatically provided to the tabs
+    // created in the zone, but can be overridden on a per-tab basis if needed.
+    let zone_services = ZoneServices {
+        storage: Arc::new(StorageService::new(
+            Arc::new(InMemoryLocalStore::new()),
+            Arc::new(InMemorySessionStore::new()),
+        )),
+        cookie_store: None,
+        cookie_jar: Some(DefaultCookieJar::new().into()),
+        partition_policy: PartitionPolicy::None,
+    };
+
+    // Create the zone. Note that we can define our own zone ID to keep zones deterministic
+    // (like a user profile), and we give the zone handle to the event channel so we can
+    // receive events related to the zone.
+    let mut zone = engine.create_zone(zone_cfg, zone_services, None)?;
+
+    let mut tab_id_to_idx: HashMap<TabId, usize> = HashMap::new();
+
+    // Next, we create a tab in the zone. For now, we don't provide anything, but we should
+    // be able to provide tab-specific services (like a different cookie jar, etc.)
+    let mut tabs = Vec::new();
+    for i in 0..25 {
+        let def_values = TabDefaults {
+            url: None,
+            title: Some(format!("Tab {i}")),
+            viewport: Some(Viewport::new(0, 0, 800, 600)),
+        };
+
+        let tab = zone
+            .create_tab(def_values.clone(), None)
+            .await
+            .expect("cannot create tab");
+
+        tab_id_to_idx.insert(tab.tab_id, i);
+        tabs.push(tab);
+    }
+
+    #[allow(unused)]
+    let autoexec_handle = tokio::spawn(async move {
+        let domains: Vec<&'static str> = vec![
+            "google.com", "bing.com", "yahoo.com",
+            "wikipedia.org", "archive.org", "rust-lang.org",
+            "github.com", "stackoverflow.com", "news.ycombinator.com",
+            "x.com", "twitter.com", "facebook.com", "instagram.com", "linkedin.com", "tiktok.com", "reddit.com",
+            "youtube.com", "netflix.com", "spotify.com", "imdb.com",
+            "amazon.com", "apple.com", "microsoft.com", "cloudflare.com",
+            "nytimes.com", "bbc.co.uk", "theguardian.com", "reuters.com", "bloomberg.com", "cnn.com", "arstechnica.com", "theverge.com",
+        ];
+
+        loop {
+            let tab = {
+                let mut rng = rng();
+                tabs.choose(&mut rng).unwrap()
+            };
+
+            let domain = {
+                let mut rng = rng();
+                let dn = *domains.choose(&mut rng).unwrap();
+                format!("https://{dn}")
+            };
+
+            tab.navigate(domain).await.unwrap();
+            sleep(Duration::from_secs(1)).await;
+        }
+    });
+
+    // This is the application's main loop, where we receive events from the engine and
+    // act on them. In a real application, you would probably want to run this in
+    // a separate task/thread, and not block the main thread.
+
+    let mut seen_intervals = 0usize;
+    let mut seen_frames = 0usize;
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+
+    loop {
+        tokio::select! {
+            Ok(ev) = event_rx.recv() => {
+                // println!("Received event: {:?}", ev);
+
+                // Just count the frames we see for now
+                if matches!(ev, EngineEvent::Redraw { .. }) {
+                    seen_frames += 1;
+//                    println!("Total frames seen so far: {seen_frames}");
+                }
+                handle_event(ev);
+            }
+            _ = tokio::signal::ctrl_c() => {
+//                println!("Received Ctrl-C, shutting down...");
+                break;
+            }
+            _ = interval.tick() => {
+//                println!("Ticking the UA interval");
+
+                seen_intervals += 1;
+                if seen_intervals >= 1000 {
+//                    println!("Seen {seen_intervals} intervals, exiting main loop");
+                    break;
+                }
+            }
+        }
+    }
+
+//    println!("Shutting down engine...");
+    engine.shutdown().await?;
+
+    // Wait for the engine task to finish
+    if let Some(handle) = engine_join_handle {
+        if let Err(join_err) = handle.await {
+            eprintln!("engine task panicked: {join_err}");
+        }
+    }
+
+    println!("Done. Exiting. Seen frames: {}", seen_frames);
+    Ok(())
+}
+
+fn handle_event(ev: EngineEvent) {
+    match ev {
+        EngineEvent::TabCreated { tab_id, .. } => {
+            UI.lock().update(tab_id, "created");
+        }
+        EngineEvent::Load { tab_id, event } => {
+            let mut ui = UI.lock();
+            match event {
+                LoadEvent::Started { url, .. }   =>
+                    ui.update(tab_id, format!("load: [STAR] {:20}", url)),
+                LoadEvent::Progress { url, finished, bytes_received, ttfb, .. }  =>
+                    ui.update(tab_id, format!("load: [DOWN] {:20} TTFB: {ttfb} FIN: {finished} RX: {bytes_received}", url)),
+                LoadEvent::Finished { url, bytes, .. }  =>
+                    ui.update(tab_id, format!("load: [FINI] {:20} {bytes}", url)),
+                LoadEvent::Failed { url, error, .. }    =>
+                    ui.update(tab_id, format!("load: [FAIL] {:20} {error}", url)),
+                LoadEvent::Cancelled { url, reason, .. } =>
+                    ui.update(tab_id, format!("load: [CNCL] {:20} {reason}", url)),
+            }
+        }
+        EngineEvent::Navigation { tab_id, event } => {
+            let mut ui = UI.lock();
+            match event {
+                NavigationEvent::Started   { url, .. } => ui.update(tab_id, format!("nav: → {url}")),
+                NavigationEvent::Committed { url, .. } => ui.update(tab_id, format!("nav: committed {url}")),
+                NavigationEvent::Finished  { url, .. } => ui.update(tab_id, format!("nav: finished {url}")),
+                NavigationEvent::Failed    { url, error, .. } =>
+                    ui.update(tab_id, format!("nav: FAILED {url} ({error})")),
+                NavigationEvent::Cancelled { url, reason, .. } =>
+                    ui.update(tab_id, format!("nav: cancelled {url} [{reason:?}]")),
+                NavigationEvent::Progress { received_bytes, expected_length, elapsed, .. } => {
+                    ui.update(tab_id, format!("nav: progress: {} {} {:?}", received_bytes, expected_length.unwrap_or(0), elapsed));
+                }
+                NavigationEvent::FailedUrl { url, error, .. } => {
+                    ui.update(tab_id, format!("nav: failed: {} {}", url, error));
+                }
+            }
+        }
+        EngineEvent::Resource { tab_id, event } => {
+            // Build a compact one-line summary per event
+            let mut ui = UI.lock();
+            match event {
+                ResourceEvent::Queued { kind, priority, .. } =>
+                    ui.update(tab_id, format!("res: queued {kind:?} pri={priority}")),
+                ResourceEvent::Started { url, .. } =>
+                    ui.update(tab_id, format!("res: started {url}")),
+                ResourceEvent::Redirected { from, to, status, .. } =>
+                    ui.update(tab_id, format!("res: redirect {status} {from} → {to}")),
+                ResourceEvent::Progress { received_bytes, .. } =>
+                    ui.update(tab_id, format!("res: {received_bytes} bytes…")),
+                ResourceEvent::Headers { status, content_length, content_type, .. } => {
+                    let mut s = String::new();
+                    let _ = write!(
+                        s,
+                        "res: headers {status} len={} type={}",
+                        content_length.map(|n| n.to_string()).unwrap_or_else(|| "unknown".into()),
+                        content_type.unwrap_or_default()
+                    );
+                    ui.update(tab_id, s);
+                }
+                ResourceEvent::Finished { url, received_bytes, elapsed, .. } => {
+                    let kb = received_bytes as f64 / 1024.0;
+                    ui.update(tab_id, format!("res: finished {} {:.2}Kb ({:?})", url, kb, elapsed))
+                }
+                ResourceEvent::Failed { url, error, .. } =>
+                    ui.update(tab_id, format!("res: FAILED {url} ({error})")),
+                ResourceEvent::Cancelled { url, reason, .. } =>
+                    ui.update(tab_id, format!("res: cancelled {url} [{reason:?}]")),
+            }
+        }
+        EngineEvent::Redraw { tab_id, .. } => {
+            UI.lock().update(tab_id, "frame ready");
+        }
+        EngineEvent::TabClosed { tab_id, .. } => {
+            UI.lock().done(tab_id);
+        }
+        _other => {
+            // UI.lock().update(TabId(0), format!("{other:?}")); // or ignore/log elsewhere
+        }
+    }
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -14,6 +14,7 @@ pub mod zone;
 
 pub mod config;
 pub mod types;
+mod downloader;
 
 pub use context::BrowsingContext;
 pub use engine::GosubEngine;

--- a/src/engine/context.rs
+++ b/src/engine/context.rs
@@ -41,8 +41,8 @@ use url::Url;
 
 // #[derive(Debug, thiserror::Error)]
 // pub enum LoadError {
-//     #[error("navigation canceled")]
-//     Canceled,
+//     #[error("navigation cancelled")]
+//     Cancelled,
 //     #[error(transparent)]
 //     Net(#[from] reqwest::Error),
 // }
@@ -126,7 +126,7 @@ impl BrowsingContext {
     //         _ = cancel.cancelled() => {
     //             self.failed = true;
     //             self.set_raw_html("<pre>Load cancelled</pre>");
-    //             return Err(LoadError::Canceled);
+    //             return Err(LoadError::Cancelled);
     //         }
     //         r = fetch(url) => {
     //             match r {

--- a/src/engine/downloader.rs
+++ b/src/engine/downloader.rs
@@ -1,0 +1,107 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+use anyhow::anyhow;
+use tokio::sync::mpsc;
+use crate::engine::types::NavigationId;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::task::JoinHandle;
+use crate::events::{EngineEvent, NavigationEvent};
+use crate::net::types::{BodyStream, FetchResultMeta};
+use crate::tab::TabId;
+
+#[allow(unused)]
+pub fn start_download(
+    tab_id: TabId,
+    nav_id: NavigationId,
+    meta: FetchResultMeta,
+    mut stream: BodyStream,
+    dest: PathBuf,
+    event_tx: mpsc::Sender<EngineEvent>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let started = Instant::now();
+
+        // tell the engine a download started
+        let _ = event_tx.send(EngineEvent::Navigation {
+            tab_id,
+            event: NavigationEvent::Started {
+                nav_id,
+                url: meta.final_url.clone(),
+            },
+        }).await;
+
+        let mut file = match tokio::fs::File::create(&dest).await {
+            Ok(f) => f,
+            Err(e) => {
+                let _ = event_tx.send(EngineEvent::Navigation {
+                    tab_id,
+                    event: NavigationEvent::Failed {
+                        nav_id: Some(nav_id),
+                        url: meta.final_url.clone(),
+                        error: Arc::new(anyhow!(e)),
+                    },
+                }).await;
+                return;
+            }
+        };
+
+        let mut buf = [0u8; 64 * 1024];
+        let mut written: u64 = 0;
+
+        loop {
+            let n = match stream.read(&mut buf).await {
+                Ok(0) => break, // Eof
+                Ok(n) => n,
+                Err(e) => {
+                    let _ = event_tx.send(EngineEvent::Navigation {
+                        tab_id,
+                        event: NavigationEvent::Failed {
+                            nav_id: Some(nav_id),
+                            url: meta.final_url.clone(),
+                            error: Arc::new(anyhow!(e)),
+                        },
+                    });
+
+                    return;
+                }
+            };
+
+            if let Err(e) = file.write_all(&buf[..n]).await {
+                let _ = event_tx.send(EngineEvent::Navigation {
+                    tab_id,
+                    event: NavigationEvent::Failed {
+                        nav_id: Some(nav_id),
+                        url: meta.final_url.clone(),
+                        error: Arc::new(anyhow!("Failed to write to file: {}", e)),
+                    },
+                });
+
+                return;
+            }
+
+            written += n as u64;
+
+            let _ = event_tx.send(EngineEvent::Navigation {
+                tab_id,
+                event: NavigationEvent::Progress {
+                    nav_id,
+                    received_bytes: written,
+                    expected_length: meta.content_length,
+                    elapsed: started.elapsed(),
+                },
+            }).await;
+        }
+
+        // Ensure data hits disk
+        let _ = file.flush().await;
+
+        let _ = event_tx.send(EngineEvent::Navigation {
+            tab_id,
+            event: NavigationEvent::Finished {
+                nav_id,
+                url: meta.final_url.clone(),
+            },
+        }).await;
+    })
+}

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -31,6 +31,9 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
+use crate::net::{spawn_io_thread, FetcherConfig, IoHandle};
+use crate::net::types::FetchRequest;
+use crate::util::spawn_named;
 
 pub struct GosubEngine {
     /// Context is what can be shared downstream
@@ -43,6 +46,9 @@ pub struct GosubEngine {
     cmd_rx: Option<mpsc::Receiver<EngineCommand>>,
     /// Is the engine running?
     running: bool,
+
+    /// I/O thread handle
+    io_handle: Option<IoHandle>,
 }
 
 // Engine context that is shared downwards to zones.
@@ -54,6 +60,8 @@ pub struct EngineContext {
     pub event_tx: broadcast::Sender<EngineEvent>,
     /// Global engine configuration
     pub config: Arc<EngineConfig>,
+    /// I/O thread handle
+    pub io_tx: Arc<RwLock<Option<mpsc::UnboundedSender<FetchRequest>>>>,
 }
 
 impl GosubEngine {
@@ -80,10 +88,12 @@ impl GosubEngine {
                 backend: Arc::new(RwLock::new(backend)),
                 event_tx: event_tx.clone(),
                 config: Arc::new(resolved_config),
+                io_tx: Arc::new(RwLock::new(None)),
             }),
             zones: HashMap::new(),
             cmd_tx,
             cmd_rx: Some(cmd_rx),
+            io_handle: None,
             running: false,
         }
     }
@@ -94,13 +104,19 @@ impl GosubEngine {
             return Err(EngineError::AlreadyRunning);
         }
 
+        // Start I/O thread
+        let io_cfg = FetcherConfig::default();
+        let io_handle = spawn_io_thread(io_cfg);
+        let tx_submit = io_handle.subscribe();
+        {
+            let mut guard = self.context.io_tx.write().unwrap();
+            *guard = Some(tx_submit);
+        }
+        self.io_handle= Some(io_handle);
+
+        // Start main engine run loop
         let join_handle = if let Some(task) = self.run() {
-            Some(
-                tokio::task::Builder::new()
-                    .name("Engine runner")
-                    .spawn(task)
-                    .map_err(|e| EngineError::Internal(e.into()))?,
-            )
+            Some(spawn_named("Engine runner", task))
         } else {
             None
         };
@@ -141,7 +157,6 @@ impl GosubEngine {
     pub fn run<'a, 'b>(&'a mut self) -> Option<impl std::future::Future<Output = ()> + 'b> {
         self.running = true;
 
-        println!("Sending engine started event");
         let _ = self.context.event_tx.send(EngineEvent::EngineStarted);
 
         let mut cmd_rx = self.cmd_rx.take()?;
@@ -150,7 +165,7 @@ impl GosubEngine {
             while let Some(cmd) = cmd_rx.recv().await {
                 match cmd {
                     EngineCommand::Shutdown { reply } => {
-                        println!("Engine received shutdown command. Shutting down main engine::run() loop");
+                        // println!("Engine received shutdown command. Shutting down main engine::run() loop");
                         let _ = reply.send(Ok(()));
                         break;
                     }
@@ -159,7 +174,7 @@ impl GosubEngine {
                     }
                 }
             }
-            println!("run() loop has exited")
+//            println!("run() loop has exited")
         })
     }
 
@@ -167,6 +182,12 @@ impl GosubEngine {
     pub async fn shutdown(&mut self) -> Result<(), EngineError> {
         if !self.running {
             return Err(EngineError::NotRunning);
+        }
+
+        // Shutdown I/O thread
+//        println!("Shutting down I/O thread");
+        if let Some(io_handle) = self.io_handle.take() {
+            io_handle.shutdown().await
         }
 
         // Send shutdown command to the run loop

--- a/src/engine/errors.rs
+++ b/src/engine/errors.rs
@@ -75,4 +75,7 @@ pub enum EngineError {
 
     #[error("Engine is not running")]
     NotRunning,
+
+    #[error("I/O runtime not started")]
+    IoNotStarted,
 }

--- a/src/engine/events.rs
+++ b/src/engine/events.rs
@@ -21,12 +21,13 @@ use crate::tab::TabId;
 use crate::zone::ZoneId;
 use crate::EngineError;
 use bitflags::bitflags;
-use std::fmt::{Debug, Display};
+use std::fmt::{Debug, Display, Formatter};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::oneshot;
 use url::Url;
-use crate::engine::types::{NavigationId, RequestId};
-use crate::net::types::{Initiator, ResourceKind};
+use crate::engine::types::{NavigationId, RequestId, Action};
+use crate::net::types::{FetchResultMeta, Initiator, Priority, ResourceKind};
 
 /// Represents a mouse button that can be pressed or released
 #[derive(Debug, Clone, PartialEq)]
@@ -92,8 +93,10 @@ pub enum TabCommand {
     Navigate { url: String },
     /// Reload current URL (with or without cache)
     Reload { ignore_cache: bool },
-    /// Cancel the current load (if any)
-    StopLoading,
+    /// Cancel the current navigation
+    CancelNavigation,
+    /// Make a decision what to do with the navigated resource
+    Decision { nav_id: NavigationId, action: Action },
     /// Close tab
     CloseTab,
 
@@ -188,35 +191,41 @@ pub enum EngineCommand {
 /// events triggered in this navigation will have the same navigation id.
 #[derive(Debug, Clone)]
 pub enum NavigationEvent {
-    Started   { nav_id: NavigationId, url: String },
-    Committed { nav_id: NavigationId, url: String }, // new doc will replace old one
-    Finished  { nav_id: NavigationId, url: String },
-    Failed    { nav_id: Option<NavigationId>, url: String, error: String },
-    Cancelled { nav_id: NavigationId, url: String, reason: CancelReason },
+    Started   { nav_id: NavigationId, url: Url },
+    Committed { nav_id: NavigationId, url: Url }, // new doc will replace old one
+    Finished  { nav_id: NavigationId, url: Url },
+    Failed    { nav_id: Option<NavigationId>, url: Url, error: Arc<anyhow::Error> },
+    Progress  { nav_id: NavigationId, received_bytes: u64, expected_length: Option<u64>, elapsed: Duration },
+    FailedUrl { nav_id: Option<NavigationId>, url: String, error: Arc<anyhow::Error> },
+    Cancelled { nav_id: NavigationId, url: Url, reason: CancelReason },
 }
 
 /// Start of loading the main document for this navigation
 #[derive(Debug, Clone)]
 pub enum LoadEvent {
-    Started   { nav_id: NavigationId, url: String },
-    Finished  { nav_id: NavigationId, url: String, bytes: u64, content_type: Option<String> },
-    Failed    { nav_id: Option<NavigationId>, url: String, error: String },
-    Cancelled { nav_id: NavigationId, url: String, reason: CancelReason },
+    Started   { nav_id: NavigationId, url: Url },
+    Finished  { nav_id: NavigationId, url: Url, bytes: u64, content_type: Option<String> },
+    Failed    { nav_id: Option<NavigationId>, url: Url, error: Arc<anyhow::Error> },
+    Cancelled { nav_id: NavigationId, url: Url, reason: CancelReason },
+    Progress  { nav_id: NavigationId, url: Url, finished: bool, bytes_received: u64, ttfb: bool, elapsed: Duration },
 }
-
-/// Priority for fetching resources. This comes into effect when the fetcher does not have enough
-/// slots to process all the backlog resources and must make decisions on what to fetch first
-#[allow(unused)]
-pub const PRIO_HIGHEST: i8 = i8::MAX;
-#[allow(unused)]
-pub const PRIO_DEFAULT: i8 = 0;
-#[allow(unused)]
-pub const PRIO_LOWEST: i8 = i8::MIN;
 
 /// Events triggered by load resources for a main document. Note that resources can trigger other
 /// resources. @TODO: how do we see this?
 #[derive(Debug, Clone)]
 pub enum ResourceEvent {
+    Queued {
+        /// Navigation ID that triggered loading this resource
+        nav_id: NavigationId,
+        /// Actual URL of the resource
+        url: String,
+        /// Type of resource
+        kind: ResourceKind,
+        /// Source that initiated this resource load
+        initiator: Initiator,
+        /// At which priority it is queued
+        priority: Priority,
+    },
     /// Loading of the resource started
     Started {
         /// Navigation ID that triggered loading this resource
@@ -229,8 +238,6 @@ pub enum ResourceEvent {
         kind: ResourceKind,
         /// Source that initiated this resource load
         initiator: Initiator,
-        /// Priority of the resource
-        priority: i8,
     },
     /// Resource responded by a redirection to another resource (will trigger a new "Started")
     Redirected {
@@ -249,16 +256,18 @@ pub enum ResourceEvent {
         req_id: RequestId,
         /// Amount of bytes received
         received_bytes: u64,
+        /// Expected length (based on content-length for instance)
+        expected_length: Option<u64>,
+        /// Time since start of the resource fetch
+        elapsed: Duration
     },
     /// Emitted when we have finished the complete resource
     Finished {
         nav_id: NavigationId,
         req_id: RequestId,
-        url: String,
+        url: Url,
         /// Total bytes received
-        bytes: u64,
-        /// Content type received (if any)
-        content_type: Option<String>,
+        received_bytes: u64,
         /// Time spend from connection open to complete fetch of the resource
         elapsed: Option<Duration>,
     },
@@ -268,7 +277,7 @@ pub enum ResourceEvent {
         req_id: RequestId,
         url: String,
         /// Reason the resource fetch failed
-        error: String,
+        error: Arc<anyhow::Error>,
     },
     /// Emitted when the resource loading has been cancelled
     Cancelled {
@@ -277,6 +286,15 @@ pub enum ResourceEvent {
         url: String,
         /// Reason for cancellation
         reason: CancelReason,
+    },
+    Headers {
+        nav_id: NavigationId,
+        req_id: RequestId,
+        url: String,
+        status: u16,
+        content_length: Option<u64>,
+        content_type: Option<String>,
+        headers: Vec<(String, String)>,
     },
 }
 
@@ -293,6 +311,19 @@ pub enum CancelReason {
     Timeout,
     /// Custom reason
     Custom(String),
+}
+
+impl Display for CancelReason {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CancelReason::NewNavigation => write!(f, "Cancelling Navigation"),
+            CancelReason::TabClosed => write!(f, "Cancelling tab closed"),
+            CancelReason::ExplicitCancel => write!(f, "Cancelling explicit cancel"),
+            CancelReason::Timeout => write!(f, "Cancelling timeout"),
+            CancelReason::Custom(msg) => write!(f, "{}", msg),
+        }
+
+    }
 }
 
 /// Engine events
@@ -341,8 +372,13 @@ pub enum EngineEvent {
     // ****************************************
     // ** Navigation
 
+    // Navigation events (for main document)
     Navigation { tab_id: TabId, event: NavigationEvent },
+    /// Response metadata for decision on navigation
+    DecisionRequest { tab_id: TabId, nav_id: NavigationId, meta: FetchResultMeta },
+    /// Load events for main document
     Load { tab_id: TabId, event: LoadEvent },
+    /// Lowlevel resource events for all resources loaded
     Resource { tab_id: TabId, event: ResourceEvent },
 
     // /// Redirect occurred
@@ -353,7 +389,6 @@ pub enum EngineEvent {
 
     /// Network connection has been established
     ConnectionEstablished { tab_id: TabId, url: String },
-
 
     // ****************************************
     // ** Tab lifecycle
@@ -381,6 +416,7 @@ pub enum EngineEvent {
 
     // ****************************************
     // ** Media / scripting
+
     /// Media has started
     MediaStarted { tab_id: TabId, element_id: u64 },
     /// Media has paused
@@ -388,7 +424,9 @@ pub enum EngineEvent {
     /// Result of a script is returned (console stuff?)
     ScriptResult { tab_id: TabId, result: serde_json::Value },
 
-    // Errors / diagnostics
+    // ****************************************
+    // ** Errors / diagnostics
+
     /// Network error occurred
     NetworkError { tab_id: TabId, url: Url, message: String },
     /// Javascript (parse) error
@@ -400,6 +438,7 @@ pub enum EngineEvent {
     },
     /// Engine crashed
     TabCrashed { tab_id: TabId, reason: String },
+
     // Uncategorized / generic
 }
 

--- a/src/engine/pipeline/document_entry.rs
+++ b/src/engine/pipeline/document_entry.rs
@@ -1,0 +1,47 @@
+pub fn start_document_pipeline(
+    meta: ResponseMeta,
+    stream: BodyStream,
+    cancel: CancellationToken,
+    event_tx: mscp::Sender<EngineEvent>,
+) {
+    tokio::spawn(async move {
+        // let res = parse_main_document_stream(
+        //     tab_id, meta.nav_id, meta.final_url.clone(),
+        //     stream, cancel.clone(), /* ignore_cache */ false, event_tx.clone()
+        // ).await;
+
+        let res = Result<(), String> = Ok(());
+
+        match res {
+            Ok(()) => {
+                let _ = event_tx.send(EngineEvent::NavigationEvent {
+                    tab_id: meta.tab_id,
+                    nav_id: meta.nav_id,
+                    event: NetEvent::Finished {
+                        result: Ok(NavigationOutput {
+                            meta,
+                            resource: Resource {
+                                kind: ResourceKind::Document,
+                                url: meta.final_url,
+                                mime_type: "text/html".into(),
+                                size: 0, // Placeholder
+                                last_modified: None,
+                                headers: HeaderMap::new(),
+                            },
+                        }),
+                    },
+                }).await;
+            }
+            Err(e) => {
+                let _ = event_tx.send(EngineEvent::NavigationEvent {
+                    tab_id: meta.tab_id,
+                    nav_id: meta.nav_id,
+                    event: NetEvent::Failed {
+                        url: meta.final_url,
+                        error: e,
+                    },
+                }).await;
+            }
+        }
+    })
+}

--- a/src/engine/tab/state.rs
+++ b/src/engine/tab/state.rs
@@ -1,8 +1,8 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use url::Url;
 use crate::engine::types::NavigationId;
-use crate::net::Response;
+use crate::net::ResourceLoadResult;
 use crate::render::Viewport;
 
 /// Represents an in-flight network load operation. It allows for easy cancellation in case
@@ -11,7 +11,7 @@ use crate::render::Viewport;
 pub(crate) struct InflightLoad {
     pub nav_id: NavigationId,
     pub cancel: CancellationToken,
-    pub rx: tokio::sync::oneshot::Receiver<(NavigationId, anyhow::Result<Response>)>,
+    pub rx: tokio::sync::oneshot::Receiver<(NavigationId, ResourceLoadResult)>,
 }
 
 /// State for the tab task driving a single tab.
@@ -24,12 +24,14 @@ pub(crate) struct TabRuntime {
     pub interval: tokio::time::Interval,
     /// Current in-flight load operation, if any
     pub load: Option<InflightLoad>,
+    /// Currently loading URL (if any)
+    pub loaded_url: Option<Url>,
     // /// Current viewport size
     // pub viewport: Viewport,
     /// Has something changed that requires a redraw
     pub dirty: bool,
     // When the last tick draw was done
-    pub last_tick_draw: Instant,
+    pub last_tick_draw: std::time::Instant,
 }
 
 impl Default for TabRuntime {
@@ -41,9 +43,10 @@ impl Default for TabRuntime {
             fps,
             interval: tokio::time::interval(Duration::from_secs_f64(1.0 / fps as f64)),
             load: None,
+            loaded_url: None,
             // viewport: Viewport::default(),
             dirty: false,
-            last_tick_draw: Instant::now(),
+            last_tick_draw: std::time::Instant::now(),
         }
     }
 }

--- a/src/engine/tab/tab.rs
+++ b/src/engine/tab/tab.rs
@@ -74,7 +74,7 @@ pub fn create_tab_and_spawn(
     services: EffectiveTabServices,
     zone_context: Arc<ZoneContext>,
 ) -> anyhow::Result<(TabHandle, JoinHandle<()>)> {
-    let (handle, worker) = create_tab(zone_id, services, zone_context)?;
-    let join = worker.spawn_named(format!("Tab Worker {}", handle.tab_id.0))?;
-    Ok((handle, join))
+    let (tab_handle, worker) = create_tab(zone_id, services, zone_context)?;
+    let join_handle = worker.spawn_worker()?;
+    Ok((tab_handle, join_handle))
 }

--- a/src/engine/tab/worker.rs
+++ b/src/engine/tab/worker.rs
@@ -1,3 +1,4 @@
+use std::io::Cursor;
 use crate::engine::events::{CancelReason, EngineEvent, LoadEvent, NavigationEvent};
 use crate::engine::BrowsingContext;
 use crate::events::TabCommand;
@@ -8,18 +9,49 @@ use crate::storage::{StorageEvent, StorageHandles};
 use crate::tab::{TabId, TabSink};
 use crate::zone::{ZoneContext, ZoneId};
 use std::sync::Arc;
-use std::time::Instant;
-use anyhow::Context;
-use tokio::sync::{mpsc, oneshot};
+use anyhow::{anyhow, Context};
+use http::Method;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::select;
 use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 use url::Url;
-use crate::engine::types::NavigationId;
-use crate::net::{load_main_document, DocumentLoadResult};
-use crate::net::types::{Initiator, ResourceKind};
+use crate::net::{NavigationError, Resource, ResourceLoadResult, SharedBody};
+use crate::net::types::{FetchKeyData, FetchRequest, FetchResult, FetchResultMeta, Initiator, Priority, ResourceKind};
 use crate::tab::services::EffectiveTabServices;
 use crate::tab::state::{InflightLoad, TabActivityMode, TabRuntime, TabState};
+use tokio::time::{sleep, Duration, Instant};
+use crate::engine::types::NavigationId;
+use crate::net::loader::{Document, NavigationOutput, ResourceMeta};
+use crate::net::mime::MimeKind;
+
+#[allow(unused)]
+enum InFlightState {
+    WaitingMeta {
+        cancel: CancellationToken,
+    },
+    WaitingDecision {
+        meta: FetchResultMeta,
+        // lease: BodyLease,
+        cancel: CancellationToken,
+    },
+    ConsumingByUA {
+        cancel: CancellationToken,
+    },
+    ConsumingByEngine {
+        cancel: CancellationToken,
+    },
+    Done,
+}
+
+impl InFlightState {
+    #[allow(unused)]
+    fn is_done(&self) -> bool {
+        matches!(self, InFlightState::Done)
+    }
+}
 
 pub struct TabWorker {
     /// ID of the tab
@@ -63,14 +95,18 @@ pub struct TabWorker {
     // Thumbnail image of the tab in case the tab is not visible
     pub thumbnail: Option<RgbaImage>,
     // Surface on which the browsing context can render the tab
+    #[allow(unused)]
     surface: Option<Box<dyn ErasedSurface + Send>>,
     // // Size of the surface (does not have to match viewport)
     // surface_size: SurfaceSize,
     // Present mode for the surface?
+    #[allow(unused)]
     present_mode: PresentMode,
     /// Device Pixel Ratio
+    #[allow(unused)]
     dpr: DevicePixelRatio,
     /// The viewport that was committed for the in-flight/last render
+    #[allow(unused)]
     committed_viewport: Viewport,
     /// The newest viewport requested by the tab, which may differ from the committed one.
     desired_viewport: Viewport,
@@ -80,7 +116,6 @@ pub struct TabWorker {
     /// Keeps track of the tab worker runtime data
     pub(crate) runtime: TabRuntime,
 }
-
 
 impl TabWorker {
     /// Creates a new tab. Does NOT spawn the tab worker
@@ -110,7 +145,6 @@ impl TabWorker {
             is_error: false,
             thumbnail: None,
             surface: None,
-            // surface_size: SurfaceSize { width: 1, height: 1 },
             present_mode: PresentMode::Fifo,
             dpr: DevicePixelRatio(1.0),
             committed_viewport: Default::default(),
@@ -120,13 +154,14 @@ impl TabWorker {
         }
     }
 
-    pub fn spawn_named(self, name: impl AsRef<str>) -> anyhow::Result<JoinHandle<()>> {
-        let name = name.as_ref().to_owned();
-        let join = tokio::task::Builder::new().name(&name).spawn(self.run())?;
-        Ok(join)
+    pub fn spawn_worker(self) -> anyhow::Result<JoinHandle<()>> {
+        let name = format!("Tab Worker {}", self.tab_id);
+        let join_handle = tokio::task::Builder::new().name(&name).spawn(self.run())?;
+
+        Ok(join_handle)
     }
 
-    pub async fn run(mut self) {
+    async fn run(mut self) {
         self.sink.set_worker_started_now();
 
         // Announce creation
@@ -136,7 +171,7 @@ impl TabWorker {
         });
 
         loop {
-            tokio::select! {
+            select! {
                 // Tick for redraws
                 _ = self.runtime.interval.tick(), if self.runtime.drawing_enabled => {
                     if let Err(e) = self.tick_draw().await {
@@ -148,14 +183,13 @@ impl TabWorker {
                 // In-flight load completion
                 res = async {
                     // Wait until the self.runtime.load.rx channel (if any) resolves
-                    if let Some(load) = &mut self.runtime.load {
-                        (&mut load.rx).await
-                    } else {
-                        // No self.runtime.load found, so we await indefinitately (thus not triggering this branch)
-                        futures::future::pending().await
+                    let load = self.runtime.load.take().expect("select! branch is guarded by is_some()");
+                    load.rx.await
+                },
+                if self.runtime.load.is_some() => {
+                    if let Some(loaded_url) = self.runtime.loaded_url.take() {
+                        self.on_load_result(loaded_url, res);
                     }
-                } => {
-                    self.on_load_result(res);
                 }
 
                 // Handle incoming tab commands
@@ -172,22 +206,22 @@ impl TabWorker {
         self.services.storage.drop_tab(self.zone_id, self.tab_id);
     }
 
-    fn on_load_result(&mut self, res: Result<(NavigationId, DocumentLoadResult), oneshot::error::RecvError>) {
+    fn on_load_result(&mut self, url: Url, res: Result<(NavigationId, ResourceLoadResult), oneshot::error::RecvError>) {
         let Some(current) = self.runtime.load.as_ref() else {
             return;
         };
         let current_nav = current.nav_id;
 
         match res {
-            Ok((completed_nav , Ok(resp))) => {
+            Ok((completed_nav, Ok(resp))) => {
                 if completed_nav != current_nav {
                     return
                 }
 
                 // Store any cookies found in the response into the cookie jar
-                self.services.cookie_jar.write().store_response_cookies(&resp.url, &resp.headers);
+                self.services.cookie_jar.write().store_response_cookies(&resp.meta.final_url, &resp.meta.headers);
 
-                self.current_url = Some(resp.url.clone());
+                self.current_url = Some(resp.meta.final_url.clone());
                 self.pending_url = None;
                 self.is_loading = false;
                 self.is_error = false;
@@ -195,17 +229,21 @@ impl TabWorker {
                 self.runtime.dirty = true;
                 self.runtime.load = None;
 
-                self.sink.set_current_url(resp.url.clone());
+                self.sink.set_current_url(resp.meta.final_url.clone());
 
-                self.context.set_raw_html(String::from_utf8_lossy(resp.body.as_slice()).as_ref());
+                // Set the document into the browsing context
+                if let Resource::Html(doc) = resp.resource {
+                    self.context.set_raw_html(doc.0.as_str())
+                }
+                // self.context.set_raw_html(String::from_utf8_lossy(resp.body.as_slice()).as_ref());
 
                 self.send_event(EngineEvent::Load {
                     tab_id: self.tab_id,
                     event: LoadEvent::Finished {
                         nav_id: completed_nav,
-                        url: resp.url.to_string(),
-                        bytes: resp.body.len() as u64,
-                        content_type: resp.headers
+                        url: resp.meta.final_url.clone(),
+                        bytes: 0,
+                        content_type: resp.meta.headers
                             .get("content_type")
                             .and_then(|v| v.to_str().ok())
                             .map(|s| s.to_string()),
@@ -216,7 +254,7 @@ impl TabWorker {
                     tab_id: self.tab_id,
                     event: NavigationEvent::Finished {
                         nav_id: completed_nav,
-                        url: resp.url.to_string(),
+                        url: resp.meta.final_url.clone(),
                     }
                 });
             }
@@ -231,16 +269,18 @@ impl TabWorker {
                 self.runtime.dirty = true;
                 self.runtime.load = None;
 
+                let err = Arc::new(anyhow!(e));
+
                 self.send_event(EngineEvent::Load {
                     tab_id: self.tab_id,
                     event: LoadEvent::Failed {
-                        nav_id: Some(completed_nav), url: "".into(), error: e.to_string()
+                        nav_id: Some(completed_nav), url: url.clone(), error: err.clone(),
                     },
                 });
                 self.send_event(EngineEvent::Navigation {
                     tab_id: self.tab_id,
                     event: NavigationEvent::Failed {
-                        nav_id: Some(completed_nav), url: "".into(), error: e.to_string()
+                        nav_id: Some(completed_nav), url: url.clone(), error: err.clone(),
                     },
                 });
             }
@@ -249,36 +289,35 @@ impl TabWorker {
 
                 self.send_event(EngineEvent::Load {
                     tab_id: self.tab_id,
-                    event: LoadEvent::Cancelled { nav_id: current_nav, url: "".into(), reason: CancelReason::ExplicitCancel },
+                    event: LoadEvent::Cancelled { nav_id: current_nav, url: url.clone(), reason: CancelReason::ExplicitCancel },
                 });
                 self.send_event(EngineEvent::Navigation {
                     tab_id: self.tab_id,
-                    event: NavigationEvent::Cancelled { nav_id: current_nav, url: "".into(), reason: CancelReason::ExplicitCancel },
+                    event: NavigationEvent::Cancelled { nav_id: current_nav, url: url.clone(), reason: CancelReason::ExplicitCancel },
                 });
             }
         }
     }
 
     fn handle_tab_command(&mut self, cmd: TabCommand) -> ControlFlow {
-        use ControlFlow::*;
         match cmd {
             TabCommand::CloseTab => {
-                println!("Tab {:?} received Close command, exiting", self.tab_id);
-                Break
+//                println!("Tab {:?} received Close command, exiting", self.tab_id);
+                ControlFlow::Break
             }
             TabCommand::Navigate { url } => {
                 self.navigate_to(&url, false);
-                Continue
+                ControlFlow::Continue
             }
             TabCommand::Reload { ignore_cache } => {
                 let url = self.current_url.as_ref().map(|u| u.as_str()).unwrap_or("about:blank").to_string();
                 self.navigate_to(url.as_str(), ignore_cache);
-                Continue
+                ControlFlow::Continue
             }
             TabCommand::SetViewport { x, y, width, height } => {
                 self.set_viewport(Viewport::new(x, y, width, height));
                 self.runtime.dirty = true;
-                Continue
+                ControlFlow::Continue
             }
             TabCommand::MouseMove { .. } |
             TabCommand::MouseDown { .. } |
@@ -287,24 +326,24 @@ impl TabWorker {
             TabCommand::KeyUp { .. } |
             TabCommand::CharInput { .. } => {
                 self.runtime.dirty = true;
-                Continue
+                ControlFlow::Continue
             }
             TabCommand::ResumeDrawing { fps: wanted_fps } => {
                 self.runtime.drawing_enabled = true;
                 self.runtime.fps = wanted_fps.max(1) as u32;
-                let period = std::time::Duration::from_secs_f64(1.0 / (self.runtime.fps as f64));
+                let period = Duration::from_secs_f64(1.0 / (self.runtime.fps as f64));
                 self.runtime.interval = tokio::time::interval(period);
                 self.runtime.interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
                 self.runtime.dirty = true;
-                Continue
+                ControlFlow::Continue
             }
             TabCommand::SuspendDrawing => {
                 self.runtime.drawing_enabled = false;
-                Continue
+                ControlFlow::Continue
             }
             _ => {
                 // Keep your other commands here
-                Continue
+                ControlFlow::Continue
             }
         }
     }
@@ -321,6 +360,7 @@ impl TabWorker {
     fn navigate_to(&mut self, url: impl Into<String>, ignore_cache: bool) {
         // Cancel any in-flight load
         if let Some(load) = self.runtime.load.take() {
+            log::warn!("**** Cancelling in-flight load for tab {:?}", self.tab_id);
             load.cancel.cancel();
         }
 
@@ -332,11 +372,7 @@ impl TabWorker {
                 log::error!("Tab[{:?}]: Cannot parse URL: {}", self.tab_id, e);
                 self.send_event(EngineEvent::Navigation {
                     tab_id: self.tab_id,
-                    event: NavigationEvent::Failed {
-                        nav_id: None,            // no nav_id could be created
-                        url: unvalidated_url,
-                        error: format!("Cannot parse URL: {e}"),
-                    },
+                    event: NavigationEvent::FailedUrl { nav_id: None, url: unvalidated_url , error: Arc::new(e.into()) },
                 });
                 return;
             }
@@ -348,8 +384,8 @@ impl TabWorker {
                 tab_id: self.tab_id,
                 event: NavigationEvent::Failed {
                     nav_id: None,
-                    url: real_url.to_string(),
-                    error: e.to_string(),
+                    url: real_url.clone(),
+                    error: Arc::new(e),
                 },
             });
             return;
@@ -367,52 +403,167 @@ impl TabWorker {
 
         self.send_event(EngineEvent::Navigation {
             tab_id: self.tab_id,
-            event: NavigationEvent::Started { nav_id, url: real_url.to_string() }
+            event: NavigationEvent::Started { nav_id, url: real_url.clone() }
         });
         self.send_event(EngineEvent::Load {
             tab_id: self.tab_id,
-            event: LoadEvent::Started { nav_id, url: real_url.to_string() }
+            event: LoadEvent::Started { nav_id, url: real_url.clone() }
         });
 
 
-        // Setup cancellation, the response channel and spwan the load task
+        // Setup cancellation, the response channel and spawn the load task
         let cancel = CancellationToken::new();
         let cancel_child = cancel.child_token();
-        let (tx, rx) = oneshot::channel::<(NavigationId, DocumentLoadResult)>();
-
-        let event_tx = self.zone_context.event_tx.clone();
+        let (tx_done, rx_done) = oneshot::channel::<(NavigationId, ResourceLoadResult)>();
 
         let tab_id = self.tab_id;
+        let event_tx = self.zone_context.event_tx.clone();
+        let io_tx = self.zone_context.io_tx.clone();
+        let request_url = real_url.clone();
 
-        tokio::task::Builder::new()
-            .name(&format!("Tab Load {} {}", self.tab_id.to_string(), nav_id.0))
-            .spawn(async move {
-                // Replace with your real loader; this is what your comment implied:
-                let res = load_main_document(
-                    tab_id,
+        let span = tracing::info_span!(
+            "tab_nav",
+            tab_id=%tab_id,
+            nav_id=%nav_id.0,
+            scheme=%request_url.scheme(),
+            host=%request_url.host_str().unwrap_or(""),
+            path=%request_url.path(),
+        );
+
+        tokio::spawn(async move {
+            let _e = span.enter();
+
+            // Submit a streaming fetch for the main document
+            let (tx_fetch, rx_fetch) = oneshot::channel::<FetchResult>();
+            let req = FetchRequest {
+                key_data: FetchKeyData {
+                    url: request_url.clone(),
+                    method: Method::GET,
+                    headers: Default::default(),
+                },
+                priority: Priority::High,
+                kind: ResourceKind::Document,
+                initiator: Initiator::Navigation,
+                tab_id,
+                streaming: true,
+                reply: Some(tx_fetch),
+                auto_decode: true,
+                max_bytes: None,
+                cancel: cancel_child.clone(),
+            };
+
+            if io_tx.send(req).is_err() {
+                // Couldn't send the request to the I/O thread
+                let _ = tx_done.send((
                     nav_id,
-                    real_url.clone(),
-                    cancel_child,
-                    ignore_cache,
-                    event_tx,
-                    ResourceKind::Document,         // This might not be correct
-                    Initiator::Navigation,          // This might not be correct
-                ).await;
-                let _ = tx.send((nav_id, res)); // ignore if receiver was dropped (replaced/cancelled)
-            })
-            .expect("failed to spawn tab loader");
+                    Err(NavigationError::NetworkError("I/O channel closed".into()))
+                ));
+                return;
+            }
 
-        // Store the inflight data, so we can cancel the load if needed
-        self.runtime.load = Some(InflightLoad { nav_id, cancel, rx });
+            // Wait for fetch to complete or cancellation
+            let fetch_result = select! {
+                _ = cancel_child.cancelled() => {
+                    let _ = tx_done.send((nav_id, Err(NavigationError::Cancelled("Navigation cancelled".into()))));
+                    return;
+                }
+                r = rx_fetch => match r {
+                    Ok(r) => r,
+                    Err(_) => {
+                        let _ = tx_done.send((nav_id, Err(NavigationError::NetworkError("Fetch response channel closed".into()))));
+                        return;
+                    }
+                }
+            };
+
+            // Handle fetch result
+            match fetch_result {
+                FetchResult::Stream { meta, peek, shared } => {
+                    let reader = SharedBody::combined_reader(peek, shared);
+
+                    // Do some progress reporting. TTFB. We have a Progress EngineEvent for this
+
+                    let doc = parse_main_document_stream(
+                        tab_id,
+                        nav_id,
+                        meta.final_url.clone(),
+                        reader,
+                        cancel_child.clone(),
+                        ignore_cache,
+                        event_tx.clone()
+                    ).await;
+
+                    if doc.is_err() {
+                        let _ = tx_done.send((nav_id, Err(NavigationError::Other(doc.err().unwrap()))));
+                        return;
+                    }
+
+                    let doc = doc.unwrap();
+
+                    let resource_meta = ResourceMeta {
+                        mime: MimeKind::Html,
+                        final_url: meta.final_url.clone(),
+                        content_length: Some(doc.0.len() as u64),
+                        etag: None,
+                        charset: None,
+                        last_modified: None,
+                        headers: meta.headers.clone(),
+                    };
+
+                    let _ = tx_done.send((nav_id, Ok(NavigationOutput{
+                        meta: resource_meta,
+                        resource: Resource::Html(doc),
+                    })));
+                }
+                FetchResult::Buffered { meta, body } => {
+                    let doc = parse_main_document_bytes(
+                        tab_id,
+                        nav_id,
+                        meta.final_url.clone(),
+                        &body,
+                        ignore_cache,
+                        event_tx.clone()
+                    ).await;
+
+                    if doc.is_err() {
+                        let _ = tx_done.send((nav_id, Err(NavigationError::Other(doc.err().unwrap()))));
+                        return;
+                    }
+
+                    let doc = doc.unwrap();
+
+                    let resource_meta = ResourceMeta {
+                        mime: MimeKind::Html,
+                        final_url: meta.final_url.clone(),
+                        content_length: Some(doc.0.len() as u64),
+                        etag: None,
+                        charset: None,
+                        last_modified: None,
+                        headers: meta.headers.clone(),
+                    };
+
+                    let _ = tx_done.send((nav_id, Ok(NavigationOutput{
+                        meta: resource_meta,
+                        resource: Resource::Html(Document(String::from_utf8_lossy(body.as_ref()).to_string())),
+                    })));
+                }
+
+                FetchResult::Error(err) => {
+                    let _ = tx_done.send((nav_id, Err(NavigationError::NetworkError(format!("Fetch error: {}", err)))));
+                }
+            }
+        });
+
+        self.runtime.load = Some(InflightLoad { nav_id, cancel: cancel.clone(), rx: rx_done });
     }
 
     /// Do a draw tick. This will be called based on the FPS that is requested
     async fn tick_draw(&mut self) -> anyhow::Result<()> {
-        println!("tick_draw()");
+//        println!("tick_draw()");
 
         self.sink.inc_frame();
 
-        let now = Instant::now();
+        let now = std::time::Instant::now();
         let elapsed = now - self.runtime.last_tick_draw;
         self.runtime.last_tick_draw = now;
 
@@ -420,7 +571,7 @@ impl TabWorker {
         if elapsed.as_secs_f32() > 0.0 {
             let fps = 1.0 / elapsed.as_secs_f32();
             self.sink.set_fps(fps);
-            println!("TickDraw: FPS: {:.2}", fps);
+//            println!("TickDraw: FPS: {:.2}", fps);
         };
 
         Ok(())
@@ -459,6 +610,7 @@ impl TabWorker {
 
     /// Dispatch a storage event to same-origin documents in this tab (placeholder).
     /// Intended for HTML5 storage event semantics.
+    #[allow(unused)]
     pub(crate) fn dispatch_storage_events(&mut self, origin: &url::Origin, include_iframes: bool, ev: &StorageEvent) {
         println!("Tab {:?} dispatch_storage_events called", self.tab_id);
         dbg!(&origin);
@@ -484,6 +636,7 @@ impl TabWorker {
     }
 
     /// Ensure the tab has a surface of the given size, creating it if necessary.
+    #[allow(unused)]
     fn ensure_surface(&mut self, backend: &dyn RenderBackend, size: SurfaceSize) -> anyhow::Result<()> {
         if let Some(ref surf) = self.surface {
             if surf.size() == size {
@@ -512,7 +665,7 @@ impl TabWorker {
         Ok(())
     }
 
-
+    #[allow(unused)]
     fn begin_render(&mut self, backend: &dyn RenderBackend) -> anyhow::Result<()> {
         if self.committed_viewport != self.desired_viewport {
             self.committed_viewport = self.desired_viewport;
@@ -525,6 +678,7 @@ impl TabWorker {
         Ok(())
     }
 
+    #[allow(unused)]
     fn end_render(&mut self) {
         if self.dirty_after_inflight {
             self.dirty_after_inflight = false;
@@ -544,4 +698,250 @@ enum ControlFlow {
 
 impl ControlFlow {
     fn is_break(&self) -> bool { matches!(self, ControlFlow::Break) }
+}
+
+// const PEEK_BUF_SIZE: usize = 5 * 1024;     // 5KB peek buffer
+
+const PROGRESS_BYTES_STEP: usize = 32 * 1024;       // Emit events after every 32KB received
+
+const IDLE_TIMEOUT: Duration = Duration::from_secs(5);
+
+
+
+async fn parse_main_document_stream<R>(
+    tab_id: TabId,
+    nav_id: NavigationId,
+    final_url: Url,
+    mut reader: R,
+    cancel_token: CancellationToken,
+    _ignore_cache: bool,
+    event_tx: broadcast::Sender<EngineEvent>,
+) -> anyhow::Result<Document>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    let time_start = Instant::now();
+
+    let mut buf = vec![0u8; 16 * 1024];     // 16K buffer
+    let mut total: usize = 0;
+    let mut last_progress_total: usize = 0;
+    let idle = sleep(IDLE_TIMEOUT);
+    tokio::pin!(idle);
+
+    let mut document_buffer = Vec::new();
+
+    loop {
+        select! {
+            _ = cancel_token.cancelled() => {
+                return Err(NavigationError::Cancelled("stream cancelled".into()).into());
+            }
+            _ = &mut idle => {
+                return Err(NavigationError::Timeout("stream timeout".into()).into());
+            }
+            read_res = reader.read(&mut buf) => {
+                let n = match read_res {
+                    Ok(n) => n,
+                    Err(e) => return Err(e.into()),
+                };
+
+                if n == 0 {
+                    if total != last_progress_total {
+                        let _ = event_tx.send(EngineEvent::Load{ tab_id, event: LoadEvent::Progress {
+                            nav_id,
+                            url: final_url.clone(),
+                            finished: false,
+                            ttfb: false,
+                            bytes_received: total as u64,
+                            elapsed: time_start.elapsed(),
+                        }});
+
+                        // last_progress_total = total;
+                    }
+                    break;
+                }
+
+                idle.as_mut().reset(Instant::now() + IDLE_TIMEOUT);
+
+                if total == 0 {
+                    let _ = event_tx.send(EngineEvent::Load { tab_id, event: LoadEvent::Progress {
+                        nav_id,
+                        url: final_url.clone(),
+                        finished: false,
+                        bytes_received: 0,
+                        ttfb: true,
+                        elapsed: time_start.elapsed(),
+                    }});
+                }
+
+                document_buffer.extend_from_slice(&buf[..n]);
+                total += n;
+
+                // @TODO: here we can feed our HTML5 parser / bytestream with more bytes
+
+
+                let bytes_since = total - last_progress_total;
+                if bytes_since >= PROGRESS_BYTES_STEP {
+                    last_progress_total = total;
+
+                    let _ = event_tx.send(EngineEvent::Load{tab_id, event: LoadEvent::Progress {
+                        nav_id,
+                        url: final_url.clone(),
+                        finished: false,
+                        ttfb: false,
+                        bytes_received: total as u64,
+                        elapsed: time_start.elapsed(),
+                    }});
+                }
+            }
+        }
+    }
+
+    // Parser should finish up and return a document
+
+    let _ = event_tx.send(EngineEvent::Load{tab_id, event: LoadEvent::Progress {
+        nav_id,
+        url: final_url.clone(),
+        ttfb: false,
+        finished: true,
+        bytes_received: total as u64,
+        elapsed: time_start.elapsed(),
+    }});
+
+    match String::from_utf8(document_buffer) {
+        Ok(s) => Ok(Document(s)),
+        Err(e) => Err(NavigationError::Other(anyhow!("invalid utf8: {e}")).into())
+    }
+}
+
+// async fn handle_stream(
+//     tab_id: TabId,
+//     nav_id: NavigationId,
+//     meta: &ContentMeta,
+//     shared: Arc<SharedBody>,
+//     cancel: CancellationToken,
+//     ignore_cache: bool,
+//     event_tx: broadcast::Sender<EngineEvent>,
+// ) -> ResourceLoadResult {
+//     let stream = shared.subscribe_stream()
+//         .map_err(|e: NetError| e.to_io());
+//     let mut reader = StreamReader::new(stream);
+//
+//     let mut peek = vec![0u8; PEEK_BUF_SIZE];
+//     let n_peek = match select! {
+//         _ = cancel.cancelled() => return Err(NavigationError::Cancelled("navigation cancelled".into())),
+//         r = reader.read(&mut peek) => r.map_err(|e| NavigationError::from(e))?,
+//     };
+//     peek.truncate(n_peek);
+//
+//     // Create a new reader that first reads from the peek buffer, then continues with the rest of the stream
+//     let mut first = &peek[..];
+//     let mut chain = tokio_util::io::StreamReader::new(
+//         futures_util::stream::once(async move { Ok::<_, std::io::Error>(Bytes::copy_from_slice(first)) })
+//     );
+//
+//     // Figure out from the content-type and/or the first PEEK_BUF_SIZE bytes what kind of type this resource is
+//     let header_ct = meta.content_type.as_deref();
+//     let kind = classify_mime(header_ct, Some(&peek));
+//
+//     match kind {
+//         MimeKind::Html => {
+//             let doc = parse_main_document_stream(
+//                 tab_id,
+//                 nav_id,
+//                 meta.final_url.clone(),
+//                 chain,
+//                 cancel,
+//                 ignore_cache,
+//                 event_tx
+//             ).await?;
+//             Resource::Html(doc)
+//         }
+//         MimeKind::Json => {
+//             let bytes = read_all_bounded(&mut chain, cancel.clone(), MAX_BUFFER_BYTES).await?;
+//             let value: serde_json::Value = serde_json::from_slice(&bytes) {
+//                 Ok(v) => v,
+//                 Err(e) => return Err(NavigationError::Other(anyhow!("Invalid JSON: {e}"))),
+//             };
+//             Resource::Json(value).into()
+//         }
+//         MimeKind::Image => {
+//             let bytes = read_all_bounded(&mut chain, cancel.clone(), MAX_BUFFER_BYTES).await?;
+//             Resource::Image { bytes: bytes.into(), mime: meta.content_type.clone().unwrap_or_else(|| "image/*".into()) }.into()
+//         }
+//         MimeKind::Text => {
+//             let bytes = read_all_bounded(&mut chain, cancel.clone(), MAX_BUFFER_BYTES).await?;
+//
+//             let s = String::from_utf8(bytes).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned());
+//             Resource::Text { text: s, mime: header_ct.unwrap_or("text/plain").to_string() }.into()
+//         }
+//         MimeKind::Binary => {
+//             let bytes = read_all_bounded(&mut chain, cancel.clone(), MAX_BUFFER_BYTES).await?;
+//             Resource::Binary { bytes: bytes.into(), mime: header_ct.unwrap_or("application/octet-stream").to_string() }.into()
+//         }
+//     }
+// }
+
+async fn parse_main_document_bytes(
+    tab_id: TabId,
+    nav_id: NavigationId,
+    final_url: Url,
+    bytes: &[u8],
+    _ignore_cache: bool,
+    event_tx: broadcast::Sender<EngineEvent>,
+) -> anyhow::Result<Document> {
+    let reader = Cursor::new(bytes.to_vec());       // @TODO: can we remove the to_vec() copy)
+    let cancel = CancellationToken::new();
+
+    tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(async move {
+            parse_main_document_stream(
+                tab_id,
+                nav_id,
+                final_url,
+                reader,
+                cancel,
+                _ignore_cache,
+                event_tx,
+            ).await
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use futures_util::TryStreamExt;
+    use crate::net::SharedBody;
+
+    #[tokio::test]
+    async fn shared_body_streamreader_eof() {
+        use tokio_util::io::StreamReader;
+        use tokio::io::AsyncReadExt;
+        use std::io;
+
+        let sb = SharedBody::new(16);
+
+        // Consumer
+        let mut reader = StreamReader::new(
+            sb.subscribe_stream().map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        );
+
+        // Producer
+        sb.push(Bytes::from_static(&[0u8; 8192]));
+        sb.push(Bytes::from_static(&[0u8; 8192]));
+        sb.push(Bytes::from_static(&[0u8; 8192]));
+        sb.push(Bytes::from_static(&[0u8; 8192]));
+        sb.push(Bytes::from_static(&[0u8; 1948]));
+        sb.finish();
+
+        // Drain all
+        let mut total = 0usize;
+        let mut buf = [0u8; 4096];
+        loop {
+            let n = reader.read(&mut buf).await.unwrap();
+            if n == 0 { break; }
+            total += n;
+        }
+        assert_eq!(total, 4*8192 + 1948);
+    }
 }

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -1,6 +1,30 @@
 use std::fmt::Display;
 use uuid::Uuid;
 
+/// Used to send back which action needs to be taken for a navigation request.
+/// After the engine reads the headers and the first xKb bytes, it will return
+/// a meta object with all information for the user agent to decide what to do.
+///
+/// It chould be that it's a HTML document, and the UA can decide to that the
+/// engine must render it. Or, it can fetch the HTML document, and show it (as raw)
+/// on the UI. Or, it could be a binary file, and the UA can decide to download it
+/// instead of rendering it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Action {
+    /// Engine will handle the stream
+    Render,
+    /// Stream will be directly downloaded to the specified path
+    Download { dest: std::path::PathBuf },
+    /// Stream will be opened in an external application
+    OpenExternal,
+    /// Stream will be cancelled
+    Cancel,
+    /// Stream will be rendered and mirrored to the specified path
+    RenderAndMirror { dest: std::path::PathBuf },
+}
+
+
+
 /// Navigation ID is the same for each complete load, including iframes, resources redirect etc
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct NavigationId(pub Uuid);
@@ -22,6 +46,7 @@ impl Display for NavigationId {
 pub struct RequestId(pub Uuid);
 
 impl RequestId {
+    #[allow(unused)]
     pub(crate) fn new() -> Self {
         Self(Uuid::new_v4())
     }

--- a/src/engine/zone/zone.rs
+++ b/src/engine/zone/zone.rs
@@ -16,8 +16,10 @@ use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, mpsc};
 use uuid::Uuid;
+use crate::net::types::FetchRequest;
+use crate::util::spawn_named;
 
 /// A unique identifier for a [`Zone`] within a [`GosubEngine`](crate::GosubEngine).
 ///
@@ -90,6 +92,8 @@ pub struct ZoneContext {
     pub(crate) shared_flags: SharedFlags,
     /// Event channel to send events back to the UI
     pub(crate) event_tx: broadcast::Sender<EngineEvent>,
+    /// Channel to communicate to the network I/O thread
+    pub(crate) io_tx: mpsc::UnboundedSender<FetchRequest>,
 }
 
 // Things that are shared upwards to the engine
@@ -139,7 +143,9 @@ impl Debug for Zone {
 
 /// Simple structure to hold tab info inside the zone
 struct TabInfo {
+    #[allow(unused)]
     join_handle: tokio::task::JoinHandle<()>,
+    #[allow(unused)]
     sink: Arc<TabSink>,
 }
 
@@ -178,8 +184,11 @@ impl Zone {
         ];
 
         let storage_rx = services.storage.subscribe();
-
         let event_tx = engine_context.event_tx.clone();
+        let io_tx = {
+            let guard = engine_context.io_tx.read().unwrap();
+            guard.as_ref().cloned().expect("I/O thread not running")
+        };
 
         let zone = Self {
             engine_context,
@@ -196,6 +205,7 @@ impl Zone {
                     share_cookiejar: false,
                 },
                 event_tx,
+                io_tx,
             }),
             id: zone_id,
             tabs: HashMap::new(),
@@ -339,9 +349,7 @@ impl Zone {
         let tx = self.context.event_tx.clone();
         let zone_id = self.id;
 
-        let join_handle = tokio::task::Builder::new()
-            .name("storage-events-forwarder")
-            .spawn(async move {
+        let join_handle = spawn_named("storage-events-forwarder", async move {
                 while let Ok(ev) = rx.recv().await {
                     let _ = tx.send(EngineEvent::StorageChanged {
                         tab_id: ev.source_tab,
@@ -354,7 +362,7 @@ impl Zone {
                 }
             });
 
-        join_handle.map_err(|e| EngineError::Internal(e.into()))
+        Ok(join_handle)
     }
 
     /// Closes a tab.

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,0 +1,1 @@
+mod parser;

--- a/src/html/parser.rs
+++ b/src/html/parser.rs
@@ -1,0 +1,220 @@
+use std::io;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
+use tokio_util::sync::CancellationToken;
+use url::Url;
+
+/// What kind of resource we discovered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ResourceKind {
+    Stylesheet,
+    Script,
+    Image,
+}
+
+/// A hint to the engine/IO layer that a subresource should be fetched.
+#[derive(Debug, Clone)]
+pub struct ResourceHint {
+    pub url: Url,                 // fully resolved
+    pub kind: ResourceKind,
+    pub rel: Option<String>,      // e.g., "stylesheet"
+    pub from_attr: &'static str,  // e.g., "href" or "src"
+}
+
+/// The "document" we "parsed".
+#[derive(Debug, Clone)]
+pub struct DummyDocument {
+    pub final_url: Url,
+    pub title: Option<String>,
+    /// Whole HTML as UTF-8 (best-effort).
+    pub raw_html: String,
+}
+
+/// Error type for this dummy parser.
+#[derive(thiserror::Error, Debug)]
+pub enum DocumentError {
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("URL error: {0}")]
+    Url(#[from] url::ParseError),
+
+    #[error("Cancelled")]
+    Cancelled,
+}
+
+/// Configuration knobs (can wire these into your runtime config later).
+#[derive(Debug, Clone)]
+pub struct DummyHtml5Config {
+    /// Max bytes to buffer from the stream. We read the entire stream up to this limit.
+    pub max_bytes: usize,
+}
+
+impl Default for DummyHtml5Config {
+    fn default() -> Self {
+        Self { max_bytes: 1 * 1024 * 1024 } // 1 MiB
+    }
+}
+
+/// Main entry point: read stream, synthesize a doc, and report discovered subresources.
+///
+/// - `base_url`: used to resolve relative URLs.
+/// - `reader`: the response body stream (already after UA has chosen Render).
+/// - `cancel`: cancellation token (tab/nav cancellation).
+/// - `on_discover`: callback invoked for each resource we find (enqueue fetch from here).
+pub async fn parse_main_document_stream<R, F>(
+    base_url: Url,
+    mut reader: R,
+    cancel: CancellationToken,
+    cfg: DummyHtml5Config,
+    mut on_discover: F,
+) -> Result<DummyDocument, DocumentError>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+    F: FnMut(ResourceHint) + Send,
+{
+    // Read the stream into a bounded buffer; bail if cancelled.
+    let mut buf = Vec::with_capacity(32 * 1024);
+    let mut tmp = [0u8; 16 * 1024];
+
+    loop {
+        if cancel.is_cancelled() {
+            return Err(DocumentError::Cancelled);
+        }
+        let n = reader.read(&mut tmp).await?;
+        if n == 0 {
+            break;
+        }
+        let remaining = cfg
+            .max_bytes
+            .saturating_sub(buf.len())
+            .min(n);
+        if remaining > 0 {
+            buf.extend_from_slice(&tmp[..remaining]);
+        }
+        // If we hit the cap, we still drain the stream to EOF quickly
+        // to avoid keeping the connection open unnecessarily.
+        if buf.len() >= cfg.max_bytes {
+            // Drain (non-blocking-ish) without growing memory
+            // We don't strictly need to, but it's polite to the transport.
+            let mut drain = [0u8; 16 * 1024];
+            while reader.read(&mut drain).await? != 0 {
+                if cancel.is_cancelled() {
+                    return Err(DocumentError::Cancelled);
+                }
+            }
+            break;
+        }
+    }
+
+    // Best-effort UTF-8 for discovery and title extraction.
+    let html = String::from_utf8_lossy(&buf).into_owned();
+
+    // Discover resources (css/js/img) and fire callbacks.
+    for hint in discover_resources(&html, &base_url) {
+        on_discover(hint);
+    }
+
+    // Synthesize a document (optionally extract <title>…</title>).
+    let title = discover_title(&html);
+
+    Ok(DummyDocument {
+        final_url: base_url,
+        title,
+        raw_html: html,
+    })
+}
+
+// ======== Forgiving resource discovery (regex-based) ========
+
+static RE_LINK_STYLESHEET: Lazy<Regex> = Lazy::new(|| {
+    // <link ... rel="stylesheet" ... href="...">
+    // - allow single or double quotes
+    // - allow attributes in any order
+    Regex::new(
+        r#"(?is)<\s*link\b[^>]*\brel\s*=\s*(['"])stylesheet\1[^>]*\bhref\s*=\s*(['"])(?P<href>[^"']+)\2[^>]*>"#
+    ).unwrap()
+});
+
+static RE_SCRIPT_SRC: Lazy<Regex> = Lazy::new(|| {
+    // <script ... src="...">
+    Regex::new(
+        r#"(?is)<\s*script\b[^>]*\bsrc\s*=\s*(['"])(?P<src>[^"']+)\1[^>]*>"#
+    ).unwrap()
+});
+
+static RE_IMG_SRC: Lazy<Regex> = Lazy::new(|| {
+    // <img ... src="...">
+    Regex::new(
+        r#"(?is)<\s*img\b[^>]*\bsrc\s*=\s*(['"])(?P<src>[^"']+)\1[^>]*>"#
+    ).unwrap()
+});
+
+static RE_TITLE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?is)<\s*title\s*>\s*(?P<title>.*?)\s*<\s*/\s*title\s*>"#).unwrap()
+});
+
+fn discover_title(html: &str) -> Option<String> {
+    RE_TITLE
+        .captures(html)
+        .and_then(|c| c.name("title").map(|m| m.as_str().trim().to_string()))
+}
+
+fn discover_resources(html: &str, base: &Url) -> Vec<ResourceHint> {
+    let mut out = Vec::new();
+
+    // Stylesheets
+    for cap in RE_LINK_STYLESHEET.captures_iter(html) {
+        if let Some(m) = cap.name("href") {
+            if let Ok(u) = resolve(base, m.as_str()) {
+                out.push(ResourceHint {
+                    url: u,
+                    kind: ResourceKind::Stylesheet,
+                    rel: Some("stylesheet".to_string()),
+                    from_attr: "href",
+                });
+            }
+        }
+    }
+
+    // Scripts
+    for cap in RE_SCRIPT_SRC.captures_iter(html) {
+        if let Some(m) = cap.name("src") {
+            if let Ok(u) = resolve(base, m.as_str()) {
+                out.push(ResourceHint {
+                    url: u,
+                    kind: ResourceKind::Script,
+                    rel: None,
+                    from_attr: "src",
+                });
+            }
+        }
+    }
+
+    // Images
+    for cap in RE_IMG_SRC.captures_iter(html) {
+        if let Some(m) = cap.name("src") {
+            if let Ok(u) = resolve(base, m.as_str()) {
+                out.push(ResourceHint {
+                    url: u,
+                    kind: ResourceKind::Image,
+                    rel: None,
+                    from_attr: "src",
+                });
+            }
+        }
+    }
+
+    out
+}
+
+fn resolve(base: &Url, candidate: &str) -> Result<Url, url::ParseError> {
+    // Tolerate whitespace, no-op fragments, etc.
+    let trimmed = candidate.trim();
+    if trimmed.is_empty() {
+        return Err(url::ParseError::EmptyHost);
+    }
+    base.join(trimmed)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,14 @@ pub mod net;
 
 pub mod render;
 
+pub mod util;
+
+pub mod html;
+
 pub use engine::{EngineError, GosubEngine};
+
+pub use engine::types::Action;
+pub use engine::types::NavigationId;
 
 #[doc(inline)]
 /// Tab management and browsing context API.

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,13 +1,26 @@
 //! Network utilities for making HTTP requests.
 //!
-mod fetch;
 mod response;
-mod loader;
+pub mod loader;
 pub mod types;
-mod events;
+pub mod events;
 mod emitter;
+mod utils;
+mod fetcher;
+mod io_runtime;
+mod fetch;
+mod shared_body;
+pub mod mime;
 
-pub use loader::load_main_document;
-pub use loader::DocumentLoadResult;
-pub use fetch::fetch;
+pub use loader::ResourceLoadResult;
+pub use loader::NavigationError;
+pub use loader::Resource;
+
+pub use shared_body::SharedBody;
+
 pub use response::Response;
+
+pub use io_runtime::IoHandle;
+pub use io_runtime::spawn_io_thread;
+
+pub use fetcher::FetcherConfig;

--- a/src/net/emitter.rs
+++ b/src/net/emitter.rs
@@ -1,2 +1,7 @@
+/// Emitters are a way to send NetEvents triggered by the fetch() function to other parts of the engine.
+/// Most likely, they are converted to EngineEvents, which are send over the event_tx channel to the UA.
+/// It's possible to ignore any events by using the NullEmitter.
+/// It could also be possible to send events to multiple emitters, for instance, both the EngineEvent and
+/// a json log emitter.
 pub mod engine_event_emitter;
 pub mod null_emitter;

--- a/src/net/emitter/engine_event_emitter.rs
+++ b/src/net/emitter/engine_event_emitter.rs
@@ -1,11 +1,13 @@
 use tokio::sync::broadcast;
-use crate::engine::events::{CancelReason, ResourceEvent, PRIO_DEFAULT};
+use crate::engine::events::{CancelReason, ResourceEvent};
 use crate::engine::types::{NavigationId, RequestId};
 use crate::events::EngineEvent;
 use crate::tab::TabId;
 use crate::net::events::{NetEvent, NetObserver};
 use crate::net::types::{Initiator, ResourceKind};
 
+/// Converts NetEvents into EngineEvents and send them over to the event_tx channel
+#[allow(unused)]
 pub struct EngineEventEmitter {
     pub tab_id: TabId,
     pub nav_id: NavigationId,
@@ -16,6 +18,7 @@ pub struct EngineEventEmitter {
 }
 
 impl EngineEventEmitter {
+    #[allow(unused)]
     fn emit(&self, ev: ResourceEvent) {
         let _ = self.event_tx.send(EngineEvent::Resource {
             tab_id: self.tab_id,
@@ -34,7 +37,6 @@ impl NetObserver for EngineEventEmitter {
                     url: url.to_string(),
                     kind: self.kind,
                     initiator: self.initiator,
-                    priority: PRIO_DEFAULT,
                 });
             }
             NetEvent::Redirected { from, to, status } => {
@@ -46,27 +48,41 @@ impl NetObserver for EngineEventEmitter {
                     status,
                 });
             }
-            NetEvent::ResponseHeaders { .. } => {
-                // self.emit(ResourceEvent::Progress {
-                //     nav_id,
-                //     req_id,
-                //     received_bytes: 0,
-                // });
+            NetEvent::ResponseHeaders { url, status, headers } => {
+                self.emit(ResourceEvent::Headers {
+                    nav_id: self.nav_id,
+                    req_id: self.req_id,
+                    url: url.to_string(),
+                    status,
+                    content_length: headers
+                        .get(reqwest::header::CONTENT_LENGTH)
+                        .and_then(|v| v.to_str().ok())
+                        .and_then(|s| s.parse::<u64>().ok()),
+                    content_type: headers
+                        .get(reqwest::header::CONTENT_TYPE)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_string()),
+                    headers: headers
+                        .iter()
+                        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+                        .collect(),
+                });
             }
-            NetEvent::Progress { received_bytes } => {
+            NetEvent::Progress { received_bytes, expected_length, elapsed } => {
                 self.emit(ResourceEvent::Progress {
                     nav_id: self.nav_id,
                     req_id: self.req_id,
                     received_bytes,
+                    expected_length,
+                    elapsed,
                 });
             }
-            NetEvent::Finished { url, bytes, elapsed, content_type } => {
+            NetEvent::Finished { url, received_bytes, elapsed } => {
                 self.emit(ResourceEvent::Finished {
                     nav_id: self.nav_id,
                     req_id: self.req_id,
-                    url: url.to_string(),
-                    bytes,
-                    content_type,
+                    url,
+                    received_bytes,
                     elapsed: Some(elapsed),
                 });
             }
@@ -75,7 +91,7 @@ impl NetObserver for EngineEventEmitter {
                     nav_id: self.nav_id,
                     req_id: self.req_id,
                     url: url.to_string(),
-                    error,
+                    error: error.into(),
                 });
             }
             NetEvent::Cancelled { url, reason } => {

--- a/src/net/emitter/null_emitter.rs
+++ b/src/net/emitter/null_emitter.rs
@@ -1,7 +1,8 @@
 use crate::net::events::{NetEvent, NetObserver};
 
-pub struct NullEmitter {
-}
+/// Emitter that will drop any events received
+#[allow(unused)]
+pub struct NullEmitter;
 
 impl NetObserver for NullEmitter {
     fn on_event(&self, _ev: NetEvent) {

--- a/src/net/events.rs
+++ b/src/net/events.rs
@@ -1,39 +1,52 @@
 use std::time::Duration;
+use http::HeaderMap;
 use url::Url;
 
+/// A NetObserver allows to send NetEvents to emitters
 pub trait NetObserver: Send + Sync {
     fn on_event(&self, ev: NetEvent);
 }
 
+/// Events that are send by the net::fetch() functions
 #[derive(Debug)]
 pub enum NetEvent {
+    /// Resource is started to load
     Started {
         url: Url,
     },
+    /// Resource is redirected to another URL
     Redirected {
         from: Url,
         to: Url,
         status: u16,
     },
+    /// Response headers are received
     ResponseHeaders {
         url: Url,
         status: u16,
-        content_length: Option<u64>,
-        content_type: Option<String>,
+        headers: HeaderMap,
     },
+    /// Progress updates, how many bytes already read
     Progress {
-        received_bytes: u64, // cumulative
-    },
-    Finished {
-        url: Url,
-        bytes: u64,
+        // How many bytes received in this resource
+        received_bytes: u64,
+        // Expected length of the resource (if known)
+        expected_length: Option<u64>,
+        // Time spent loading so far on this resource
         elapsed: Duration,
-        content_type: Option<String>,
     },
+    /// Resource is finished
+    Finished {
+        received_bytes: u64,
+        elapsed: Duration,
+        url: Url,
+    },
+    /// Resource failed to fetch
     Failed {
         url: Url,
-        error: String,
+        error: anyhow::Error,
     },
+    /// Resource fetching was cancelled
     Cancelled {
         url: Url,
         reason: &'static str,

--- a/src/net/fetch.rs
+++ b/src/net/fetch.rs
@@ -1,133 +1,636 @@
-use anyhow::{anyhow, Context, Result};
-use futures_util::StreamExt;
-use std::time::Instant;
+use crate::net::events::{NetEvent, NetObserver};
+use crate::net::types::{FetchResultMeta, NetError};
+use anyhow::{anyhow, Context};
+use bytes::Bytes;
+use futures_util::{stream, StreamExt, TryStreamExt};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::time::timeout;
+use tokio_util::io::StreamReader;
 use tokio_util::sync::CancellationToken;
 use url::Url;
-use crate::net::emitter::null_emitter::NullEmitter;
-use crate::net::events::{NetEvent, NetObserver};
-use crate::net::Response;
 
-// Fetch function with observer to which we can send net events to.
-pub async fn fetch(
+
+/// Peek buffer size (first bytes of body). Used for detecting mime type
+const PEEK_MAX: usize = 5 * 1024;
+/// Maximum number of redirects allowed
+const MAX_REDIRECTS: usize = 20;
+
+// This is the top of the response (HTTP headers + first 5KB of the body, if any), plus a stream (that starts from the peeked bytes)
+pub struct ResponseTop {
+    /// Metadata about the result
+    pub meta: FetchResultMeta,
+    /// Peek buffer of the first PEEK_MAX of data
+    pub peek: Vec<u8>,
+    /// Stream reader to read the REMAINDER of the body (this does NOT include peek buffer read data)
+    pub reader: Box<dyn AsyncRead + Unpin + Send>,
+}
+
+/// This function will make a request to a given URL and returns the top of the response. These
+/// are most likely the headers and the first 5 KB of body. This can be used to determine mime type
+/// of the resource fetched. It will also return a stream reader that is able to read the remainder
+/// of the body (minus the peek buffer).
+pub async fn fetch_response_top(
+    // Configured reqewst client to fetch the result
+    client: Arc<reqwest::Client>,
+    // Url to fetch (can be invalid or redirected)
     url: Url,
+    // Cancel token to detect user cancellations
     cancel: CancellationToken,
-    obs: Option<&dyn NetObserver>,
-) -> Result<Response> {
-    let obs = obs.unwrap_or(&NullEmitter {});
+    // Observer which can send out NetEvents to the UA
+    observer: Arc<dyn NetObserver + Send + Sync>,
+) -> Result<ResponseTop, NetError> {
 
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::custom({
-            // It's safe to assume that our net observer is static. It won't be freed too early
-            let obs = unsafe { std::mem::transmute::<&dyn NetObserver, &'static dyn NetObserver>(obs) };
-
-            move |attempt| {
-                if let (Some(prev), next) = (attempt.previous().last(), attempt.url()) {
-                    // Send a net event that we encountered a redirection
-                    let from = prev.clone();
-                    let to = next.clone();
-                    let status = attempt.status().as_u16();
-                    obs.on_event(NetEvent::Redirected {
-                        from,
-                        to,
-                        status,
-                    });
-                }
-                attempt.follow()
-            }
-        }))
-        .build()?;
-
-    // Start
-    obs.on_event(NetEvent::Started { url: url.clone() });
-
+    // Emit we are starting
     let started = Instant::now();
+    observer.on_event(NetEvent::Started { url: url.clone() });
 
-    // Build the request future and pin it so we can drop on cancel.
-    let req_fut = client.get(url.clone()).send();
-    tokio::pin!(req_fut);
+    // Get the response (GET requests only for now), and redirect if needed (300 requests)
+    let resp = get_with_redirects(
+        client.clone(),
+        url.clone(),
+        cancel.clone(),
+        observer.clone(),
+    )
+    .await?;
 
-    let resp = tokio::select! {
-        _ = cancel.cancelled() => {
-            // Request was cancelled
-            obs.on_event(NetEvent::Cancelled { url: url.clone(), reason: "cancelled" });
-            return Err(anyhow!("cancelled"));
-        }
-        r = &mut req_fut => r.context("request send failed")?,
+    // Response is received, setup our meta structure
+    let mut meta = FetchResultMeta {
+        final_url: resp.url().clone(),
+        status: resp.status().as_u16(),
+        status_text: resp.status().canonical_reason().unwrap_or("").to_string(),
+        headers: resp.headers().clone(),
+        content_length: resp.content_length(),
+        peek: Vec::new(), // Don't know yet
+        has_body: true,   // Don't know yet
     };
 
-    let status = resp.status().as_u16();
-    let headers = resp.headers().clone();
-    let content_type = headers
-        .get(reqwest::header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string());
-    let content_len = resp.content_length();
+    // Peek the stream up to PEEK_MAX bytes
+    let mut body_stream = resp
+        .bytes_stream()
+        .map_err(|e| NetError::Read(Arc::new(anyhow!(e))));
+    let mut received_net: u64 = 0;
+    let mut peek_buf: Vec<u8> = Vec::with_capacity(PEEK_MAX);
+    let mut excess: Option<Bytes> = None;
 
-    // Response headers found which we can emit
-    obs.on_event(NetEvent::ResponseHeaders {
-        url: resp.url().clone(),
-        status,
-        content_length: content_len,
-        content_type: content_type.clone(),
-    });
+    let observer_clone = observer.clone();
 
-    // Stream the body to emit progress, but also buffer to Vec<u8> to match your Response.
-    let mut body_stream = resp.bytes_stream();
-    let mut received: u64 = 0;
-    let mut buf: Vec<u8> = Vec::with_capacity(content_len.unwrap_or(0) as usize);
-
-    loop {
-        tokio::select! {
+    // We might need more fetches than one. Although it's unlikely unless you set PEEK_MAX to >8KB
+    while peek_buf.len() < PEEK_MAX {
+        let next = tokio::select! {
+            // Stream cancelled
             _ = cancel.cancelled() => {
-                // Stream cancelled
-                obs.on_event(NetEvent::Cancelled { url: url.clone(), reason: "body stream cancelled" });
-                return Err(anyhow!("body stream cancelled"));
+                observer_clone.on_event(NetEvent::Cancelled { url: url.clone(), reason: "peek stream cancelled" });
+                return Err(NetError::Cancelled("peek stream cancelled".into()));
             }
-            next = body_stream.next() => {
-                match next {
-                    Some(Ok(chunk)) => {
-                        received += chunk.len() as u64;
-                        buf.extend_from_slice(&chunk);
-                        // Emit progress. We probably want to see how chatty this will be, based on chunk.len()
-                        obs.on_event(NetEvent::Progress { received_bytes: received });
-                    }
-                    Some(Err(e)) => {
-                        // Something failed
-                        obs.on_event(NetEvent::Failed { url: url.clone(), error: e.to_string() });
-                        return Err(e).context("body read failed");
-                    }
-                    None => break, // done
+            // Read bytes from stream
+            n = body_stream.next() => n,
+        };
+
+        match next {
+            // We received a chunk of data
+            Some(Ok(chunk)) => {
+                received_net += chunk.len() as u64;
+
+                observer.on_event(NetEvent::Progress {
+                    received_bytes: received_net,
+                    elapsed: started.elapsed(),
+                    expected_length: meta.content_length,
+                });
+
+                let need = PEEK_MAX.saturating_sub(peek_buf.len());
+                if chunk.len() <= need {
+                    // Entire chunk fits in our peek_buf.
+                    peek_buf.extend_from_slice(&chunk);
+                } else {
+                    // Chunk does not fit. For instance: Peek Buf = 12Kb. We read 8Kb in the first
+                    // read, and 8kb in the second. In this case we have read 16kb when we only need
+                    // the first 12kb. We fill the peek buf until full, and keep the rest in the
+                    // 'excess' buffer
+                    peek_buf.extend_from_slice(&chunk[..need]);
+                    excess = Some(chunk.slice(need..));
+                    break;
                 }
+            }
+            Some(Err(e)) => {
+                // Something failed
+                observer.on_event(NetEvent::Failed {
+                    url: url.clone(),
+                    error: e.into(),
+                });
+                return Err(NetError::Read(Arc::new(anyhow!("peek read failed"))));
+            }
+            None => {
+                // Stream ended successfully
+                break;
             }
         }
     }
 
-    let elapsed = started.elapsed();
+    // Save the length before we store the excess into a body stream
+    let excess_len = excess.as_ref().map(|b| b.len() as u64).unwrap_or(0);
 
-    // Request is finished
-    obs.on_event(NetEvent::Finished {
-        url: url.clone(),
-        bytes: received,
-        elapsed,
-        content_type: content_type.clone(),
-    });
+    // It's possible that we have read too much, and we have an exccess buffer, so we create
+    // a new stream that starts at the end of the peek buffer WITH the excess buffer in front.
+    //
+    //  |--- Peek buffer ---|---- Excess buffer ----| ---- body stream ----|
+    //                                              ^ stream starts here
+    //                      ^  new body stream "rereads" the excess buffer and starts here
+    let body_stream = if let Some(ex) = excess {
+        stream::once(async move { Ok::<Bytes, NetError>(ex) })
+            .chain(body_stream)
+            .boxed()
+    } else {
+        body_stream.boxed()
+    };
 
-    // Create actual response to caller
-    let final_url = url;
-    let status_text = reqwest::StatusCode::from_u16(status)
-        .ok()
-        .map(|s| s.canonical_reason().unwrap_or(""))
-        .unwrap_or("")
-        .to_string();
+    // Update last remaining items in meta struct
+    meta.peek = peek_buf.clone();
+    let has_body_by_len = meta.content_length.unwrap_or(0) > 0 || !peek_buf.is_empty();
+    meta.has_body = has_body_by_len;
 
-    let mut headers_map = reqwest::header::HeaderMap::new();
-    headers_map.extend(headers.clone().into_iter());
+    // Wrap our body stream into a progress reader. This way it will emit net events to the observer
+    // whenever it is read.
+    let stream = body_stream.map_err(|e: NetError| e.to_io());
+    let inner_reader = StreamReader::new(stream);
 
-    Ok(Response {
-        url: final_url,
-        status,
-        status_text,
-        headers: headers_map,
-        body: buf,
+    // Update the progress counter to the point of the bytes read (note: this can cause a strange
+    // decrease in bytes read in the progress events?)
+    let already_delivered = received_net - excess_len;
+
+    let progress_reader = ProgressReader::new(
+        inner_reader,
+        cancel.clone(),
+        observer.clone(),
+        url.clone(),
+        started,
+        meta.content_length,
+        already_delivered,
+    );
+
+    Ok(ResponseTop {
+        meta,
+        peek: peek_buf,
+        reader: Box::new(progress_reader),
     })
+}
+
+/// Progres reader is a simple stream that will wrap another AsyncRead stream, and emit progress
+/// events to the observer.
+struct ProgressReader<R> {
+    /// Actual reader
+    inner: R,
+    /// Cancellation token
+    cancel: CancellationToken,
+    // Observer to emit events to
+    observer: Arc<dyn NetObserver + Send + Sync>,
+    /// Url we are reading from. For event emission
+    url: Url,
+    /// When we started reading, since we already read the peek buffer from this stream
+    started: Instant,
+    /// Expected length of the resource, if known
+    expected_length: Option<u64>,
+    /// Number of bytes already received (from the peek buffer)
+    received: u64,
+    /// Whether we already emitted a cancelled event
+    cancel_emitted: bool,
+}
+
+impl<R: AsyncRead + Unpin> ProgressReader<R> {
+    fn new(
+        inner: R,
+        cancel: CancellationToken,
+        observer: Arc<dyn NetObserver + Send + Sync>,
+        url: Url,
+        started: Instant,
+        expected_length: Option<u64>,
+        already_received: u64,
+    ) -> Self {
+        Self {
+            inner,
+            cancel,
+            observer,
+            url,
+            started,
+            expected_length,
+            received: already_received,
+            cancel_emitted: false,
+        }
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for ProgressReader<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        // When cancelled, we are directly done
+        if self.cancel.is_cancelled() {
+            // Maybe it's already cancelled? Then don't send another cancelled event
+            if !self.cancel_emitted {
+                self.observer.on_event(NetEvent::Cancelled {
+                    url: self.url.clone(),
+                    reason: "progress reader cancelled",
+                });
+                self.cancel_emitted = true;
+            }
+
+            let err = NetError::Cancelled("progress reader cancelled".into());
+            return std::task::Poll::Ready(Err(err.to_io()));
+        }
+
+        // Pull new bytes from the reader
+        let pre_len = buf.filled().len();
+        let poll = Pin::new(&mut self.inner).poll_read(cx, buf);
+
+        if let std::task::Poll::Ready(Ok(())) = &poll {
+            let new_len = buf.filled().len();
+            let read_bytes = (new_len - pre_len) as u64;
+
+            // nothing read, then we have reached the end of the stream
+            if read_bytes == 0 {
+                // Finished
+                self.observer.on_event(NetEvent::Finished {
+                    received_bytes: self.received,
+                    elapsed: self.started.elapsed(),
+                    url: self.url.clone(),
+                });
+            }
+            if read_bytes > 0 {
+                self.received += read_bytes;
+                self.observer.on_event(NetEvent::Progress {
+                    received_bytes: self.received,
+                    elapsed: self.started.elapsed(),
+                    expected_length: self.expected_length,
+                });
+            }
+        }
+
+        poll
+    }
+}
+
+/// Fetch a complete resource, returning the metadata and the full body as a Vec<u8>.
+pub async fn fetch_response_complete(
+    client: Arc<reqwest::Client>,
+    url: Url,
+    cancel: CancellationToken,
+    observer: Arc<dyn NetObserver + Send + Sync>,
+    // We can cap the amount of bytes we want to read (None for unlimited)
+    max_bytes: Option<usize>,
+    // Maximum time allowed between reads
+    read_idle_timeout: Duration,
+    // Total time of read allowed (if any)
+    total_body_timeout: Option<Duration>,
+) -> Result<(FetchResultMeta, Vec<u8>), NetError> {
+    let started = Instant::now();
+
+    let ResponseTop { meta, peek, mut reader } =
+        fetch_response_top(client, url, cancel.clone(), observer.clone()).await?;
+
+    // We don't care about the peek buffer. We just create a new buffer and read the rest of the
+    // stream into it.
+    let mut buf = peek;
+    let mut chunk = [0u8; 16 * 1024];
+
+    loop {
+        // Check if we hit the total body timeout
+        if let Some(total) = total_body_timeout {
+            if started.elapsed() > total {
+                return Err(NetError::Timeout("total body timeout".into()));
+            }
+        }
+
+        let n = tokio::select! {
+            // Stream cancelled
+            _ = cancel.cancelled() => {
+                return Err(NetError::Cancelled("fetch_request_complete cancelled".into()));
+            }
+            // Read bytes, or timeout when not read something in time
+            r = timeout(read_idle_timeout, reader.read(&mut chunk)) => {
+                match r {
+                    Err(_) => return Err(NetError::Timeout("fetch_request_complete timeout".into())),
+                    Ok(Err(e)) => return Err(NetError::Io(Arc::new(e))),
+                    Ok(Ok(n)) => n,
+                }
+            }
+        };
+
+        if n == 0 {
+            // Stream ended normally
+            break;
+        }
+
+        if let Some(max) = max_bytes {
+            // Too many bytes are read. We throw an error (@TODO: should we do this? not just cap
+            // the buffer and return that?
+            if buf.len() + n > max {
+                return Err(NetError::Read(Arc::new(anyhow!(
+                    "fetch_request_complete exceeded maximum size of {} bytes",
+                    max
+                ))));
+            }
+        }
+
+        // Exctent the bufferr with read chunk
+        buf.extend_from_slice(&chunk[..n]);
+    }
+
+    Ok((meta, buf))
+}
+
+/// Perform a GET request, following redirects up to MAX_REDIRECTS times, while sending out net events
+async fn get_with_redirects(
+    client: Arc<reqwest::Client>,
+    url: Url,
+    cancel: CancellationToken,
+    observer: Arc<dyn NetObserver + Send + Sync>,
+) -> Result<reqwest::Response, NetError> {
+    let mut url = url;
+
+    // We cap the number of redirects in order to prevent redirection loops
+    for _ in 0..MAX_REDIRECTS {
+        // Get response from the client. Note that we need to pin the future as we are using it in select!
+        let fut = client.get(url.clone()).send();
+        tokio::pin!(fut);
+
+        let resp = tokio::select! {
+            // cancelled
+            _ = cancel.cancelled() => {
+                observer.on_event(NetEvent::Cancelled { url: url.clone(), reason: "cancelled net.get_with_redirects" });
+                return Err(NetError::Cancelled("cancelled net.get_with_redirects".into()));
+            }
+            // Read response or fail
+            r = &mut fut => r.context("net.get_with_redirects request failed").map_err(|e| NetError::Read(Arc::new(e)))?
+        };
+
+        // Not a redirection, return response directly
+        if !resp.status().is_redirection() {
+            return Ok(resp);
+        }
+
+        // 3xx response detected, follow the redirect found in the Location header
+        let status = resp.status().as_u16();
+        let from = resp.url().clone();
+        let loc = resp
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| {
+                NetError::Redirect(Arc::new(anyhow!(
+                    "redirect status {} without Location header",
+                    status
+                )))
+            })?;
+
+        let to = from
+            .join(loc)
+            .map_err(|e| NetError::Redirect(Arc::new(anyhow!("invalid redirect URL '{}': {}", loc, e))))?;
+
+        observer.on_event(NetEvent::Redirected {
+            from,
+            to: to.clone(),
+            status,
+        });
+
+        url = to
+    }
+
+    Err(NetError::Redirect(Arc::new(anyhow!("too many redirects"))))
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+    use std::net::SocketAddr;
+    use std::time::Duration;
+    use tokio::io::{AsyncWriteExt as _};
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio_util::sync::CancellationToken;
+
+    struct TestObserver;
+
+    impl NetObserver for TestObserver {
+        fn on_event(&self, _event: NetEvent) {
+        }
+    }
+
+    async fn read_request(stream: &mut TcpStream) -> io::Result<String> {
+        let mut buf = Vec::with_capacity(1024);
+        let mut tmp = [0u8; 512];
+        loop {
+            let n = stream.read(&mut tmp).await?;
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&tmp[..n]);
+            if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+            if buf.len() > 16 * 1024 {
+                break;
+            }
+        }
+        Ok(String::from_utf8_lossy(&buf).to_string())
+    }
+
+    fn parse_path(req: &str) -> String {
+        if let Some(line) = req.lines().next() {
+            if let Some(rest) = line.strip_prefix("GET ") {
+                if let Some(idx) = rest.find(' ') {
+                    return rest[..idx].to_string();
+                }
+            }
+        }
+        "/".to_string()
+    }
+
+    async fn handle_conn(mut stream: TcpStream, addr: SocketAddr, peek_max: usize) -> io::Result<()> {
+        let req = read_request(&mut stream).await?;
+        let path = parse_path(&req);
+
+        match path.as_str() {
+            "/big" => {
+                // 12 KiB body to test excess logic
+                let len = 12 * 1024;
+                let body = vec![b'X'; len];
+                let hdr = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    len
+                );
+                stream.write_all(hdr.as_bytes()).await?;
+                stream.write_all(&body).await?;
+            }
+            "/redirect" => {
+                // Redirect to /big on same host
+                let hdr = format!(
+                    "HTTP/1.1 302 Found\r\nLocation: http://{}/big\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                    addr
+                );
+                stream.write_all(hdr.as_bytes()).await?;
+            }
+            "/slow" => {
+                // Send exactly PEEK_MAX bytes fast, then stall (to trigger read idle timeout later)
+                let total = peek_max + 1024;
+                let fast = peek_max;
+                let slow = total - fast;
+
+                let hdr = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n",
+                    total
+                );
+                stream.write_all(hdr.as_bytes()).await?;
+                // fast prefix
+                stream.write_all(&vec![b'A'; fast]).await?;
+                stream.flush().await?;
+                // stall long enough to exceed typical idle timeout in tests
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                // write a tiny bit so connection stays alive (not strictly needed)
+                let _ = stream.write_all(&vec![b'B'; slow]).await;
+            }
+            _ => {
+                let body = b"hello";
+                let hdr = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                stream.write_all(hdr.as_bytes()).await?;
+                stream.write_all(body).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn spawn_test_server() -> (Url, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = Url::parse(&format!("http://{}/", addr)).unwrap();
+
+        let handle = tokio::spawn(async move {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _peer)) => {
+                        // Handle each connection; we pass server addr for absolute redirect
+                        let server_addr = addr;
+                        tokio::spawn(async move {
+                            let _ = handle_conn(stream, server_addr, super::PEEK_MAX).await;
+                        });
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        (base, handle)
+    }
+
+    fn test_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none()) // we do redirects ourselves
+            .build()
+            .unwrap()
+    }
+
+    // ---------- Tests ----------
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn top_returns_peek_and_reader_rest() {
+        let (base, _jh) = spawn_test_server().await;
+
+        let client = Arc::new(test_client());
+        let url = base.join("big").unwrap();
+        let cancel = CancellationToken::new();
+        let observer: Arc<dyn NetObserver + Send + Sync> = Arc::new(TestObserver);
+
+        let ResponseTop { meta, peek, mut reader } =
+            super::fetch_response_top(client, url, cancel, observer).await.unwrap();
+
+        assert_eq!(peek.len(), super::PEEK_MAX, "peek must be exactly PEEK_MAX");
+        // Read remainder
+        let mut rest = Vec::new();
+        reader.read_to_end(&mut rest).await.unwrap();
+
+        assert_eq!(peek.len() + rest.len(), 12 * 1024);
+        assert!(meta.has_body);
+        assert_eq!(meta.status, 200);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn redirects_are_followed() {
+        let (base, _jh) = spawn_test_server().await;
+
+        let client = Arc::new(test_client());
+        let url = base.join("redirect").unwrap();
+        let cancel = CancellationToken::new();
+        let observer: Arc<dyn NetObserver + Send + Sync> = Arc::new(TestObserver);
+
+        // Small generous timeouts so the test is stable
+        let (meta, body) = super::fetch_response_complete(
+            client,
+            url,
+            cancel,
+            observer,
+            None,                           // max_bytes
+            Duration::from_secs(3),         // read_idle_timeout
+            Some(Duration::from_secs(5)),   // total_body_timeout
+        ).await.unwrap();
+
+        assert_eq!(meta.status, 200);
+        assert_eq!(body.len(), 12 * 1024);
+        assert!(meta.has_body);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn idle_timeout_triggers_on_slow_body() {
+        let (base, _jh) = spawn_test_server().await;
+
+        let client = Arc::new(test_client());
+        let url = base.join("slow").unwrap();
+        let cancel = CancellationToken::new();
+        let observer: Arc<dyn NetObserver + Send + Sync> = Arc::new(TestObserver);
+
+        // Set idle timeout < server stall (250ms)
+        let res = super::fetch_response_complete(
+            client,
+            url,
+            cancel,
+            observer,
+            None,
+            Duration::from_millis(100),     // read_idle_timeout
+            Some(Duration::from_secs(2)),   // total_body_timeout
+        ).await;
+
+        assert!(res.is_err(), "expected timeout error");
+        let err = res.err().unwrap();
+        let s = err.to_string().to_lowercase();
+        assert!(s.contains("timeout"), "error should mention timeout, got: {s}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancel_during_peek_is_honored() {
+        let (base, _jh) = spawn_test_server().await;
+
+        let client = Arc::new(test_client());
+        let url = base.join("slow").unwrap();
+        let cancel = CancellationToken::new();
+        let observer: Arc<dyn NetObserver + Send + Sync> = Arc::new(TestObserver);
+
+        // Kick off, then cancel quickly; server sends headers + PEEK_MAX fast, but we cancel immediately
+        let cancel2 = cancel.clone();
+        let fut = super::fetch_response_top(client, url, cancel.clone(), observer);
+
+        // Cancel immediately
+        cancel2.cancel();
+
+        let res = fut.await;
+        assert!(res.is_err(), "expected cancellation");
+        let s = res.err().unwrap().to_string().to_lowercase();
+        assert!(s.contains("cancel"), "error should be cancellation: {s}");
+    }
 }

--- a/src/net/fetcher.rs
+++ b/src/net/fetcher.rs
@@ -1,0 +1,528 @@
+//! This module defines the `Fetcher` struct and its associated functionality for managing
+//! and scheduling HTTP requests. It includes mechanisms for prioritizing requests, coalescing
+//! identical requests, and handling streaming or buffered responses.
+
+use crate::net::events::NetObserver;
+use crate::net::fetch::{fetch_response_complete, fetch_response_top, ResponseTop};
+use crate::net::shared_body::SharedBody;
+use crate::net::types::{FetchRequest, FetchResult, NetError, Priority};
+use crate::net::utils::{short_url, Waiter};
+use crate::util::spawn_named;
+use bytes::{Bytes, BytesMut};
+use dashmap::{DashMap, Entry};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+use std::{collections::VecDeque, sync::Arc, time::Duration};
+use tokio::io::AsyncReadExt;
+use tokio::sync::{Notify, Semaphore};
+use tokio::time::{sleep, timeout};
+use url::Url;
+
+/// How many shared consumers can listen for a resource
+const SHARED_MAX_CAPACITY: usize = 32;
+
+// Configuration for the fetcher
+#[derive(Clone)]
+pub struct FetcherConfig {
+    /// Maximum number of concurrent fetches overall
+    pub global_slots: usize,
+    /// Maximum number of concurrent HTTP/1 connections per origin
+    pub h1_per_origin: usize,
+    /// Maximum number of concurrent HTTP/2 connections per origin
+    pub h2_per_origin: usize,
+    /// TCP connect timeout
+    pub connect_timeout: Duration,
+    /// Overall request timeout
+    pub req_timeout: Duration,
+    /// Max time between reads allowed
+    pub read_idle_timeout: Duration,
+    /// Max time for total body read
+    pub total_body_timeout: Option<Duration>,
+}
+
+impl Default for FetcherConfig {
+    fn default() -> Self {
+        Self {
+            global_slots: 32,
+            h1_per_origin: 6,
+            h2_per_origin: 16,
+            connect_timeout: Duration::from_secs(5),
+            req_timeout: Duration::from_secs(60),
+            read_idle_timeout: Duration::from_secs(15),
+            total_body_timeout: Some(Duration::from_secs(180)),
+        }
+    }
+}
+
+/// RAII guard that ensures an in-flight coalescing entry is removed from the map.
+///
+/// # Why
+/// When the **leader** task inserts an entry into `inflight` (to coalesce
+/// identical requests), that entry **must** be removed even if the task exits
+/// early (e.g., cancellation, early return, or panic). If it isn’t removed,
+/// future requests may keep coalescing onto a “dead” entry and never make
+/// progress.
+///
+/// `InflightGuard` holds a clone of the `DashMap` and the key. On `Drop` it
+/// removes the entry **exactly once**. You can also remove eagerly via
+/// [`remove`](Self::remove), which consumes the guard and disables the
+/// drop-time removal.
+///
+/// # Semantics
+/// - **Idempotent:** dropping after `remove()` is a no-op.
+/// - **Panic-safe:** removal also runs during unwinding.
+/// - **Non-owning of the value:** the guard only removes by key; it doesn’t
+///   keep or access the mapped value.
+///
+/// # Example
+/// ```rust,ignore,no_run
+/// let guard = InflightGuard::new(inflight.clone(), key.clone());
+/// // ... acquire permits, do the fetch ...
+/// // Option A: explicit cleanup
+/// guard.remove(); // consumes the guard
+/// // Option B: rely on Drop (automatic cleanup at scope end)
+/// ```
+struct InflightGuard {
+    map: Arc<DashMap<String, Arc<Inflight>>>,
+    key: String,
+    removed: bool,
+}
+
+impl InflightGuard {
+    /// Create a new guard for `key` stored in `map`.
+    ///
+    /// This **does not** insert anything; it only arranges for the key to be
+    /// removed when the guard is dropped (or when [`remove`](Self::remove) is called).
+    #[inline]
+    fn new(map: Arc<DashMap<String, Arc<Inflight>>>, key: String) -> Self {
+        Self {
+            map,
+            key,
+            removed: false
+        }
+    }
+
+
+    /// Eagerly remove the in-flight entry and consume the guard.
+    ///
+    /// After this call, dropping the returned value (which no longer exists)
+    /// will do nothing.
+    #[inline]
+    fn remove(mut self) {
+        let _ = self.map.remove(&self.key);
+        self.removed = true;
+    }
+}
+
+impl Drop for InflightGuard {
+    #[inline]
+    fn drop(&mut self) {
+        if !self.removed {
+            let _ = self.map.remove(&self.key);
+        }
+    }
+}
+
+/// Represents an in-flight request, including its associated waiter and streaming preference.
+struct Inflight {
+    /// Waiter for managing requests
+    waiter: Arc<Waiter>,
+    /// True when streaming is required
+    wants_streaming: AtomicBool,
+}
+
+impl Inflight {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            waiter: Waiter::new_arc(),
+            wants_streaming: AtomicBool::new(false),
+        })
+    }
+}
+
+/// The `Fetcher` struct manages the scheduling and execution of HTTP requests.
+/// It supports prioritization, coalescing of identical requests, and streaming or buffered responses.
+pub struct Fetcher {
+    /// HTTP client for making requests
+    client: reqwest::Client,
+    /// Configuration for the fetcher
+    cfg: FetcherConfig,
+
+    /// Semaphore for limiting global current fetches
+    global_slots: Arc<Semaphore>,
+    /// Map for managing per-origin limits
+    per_origin: DashMap<String, Arc<Semaphore>>,
+
+    /// Queue for high priority requests
+    q_high: tokio::sync::Mutex<VecDeque<FetchRequest>>,
+    /// Queue for regular priority requets
+    q_norm: tokio::sync::Mutex<VecDeque<FetchRequest>>,
+    /// Queue for low priority requests
+    q_low: tokio::sync::Mutex<VecDeque<FetchRequest>>,
+    /// Queue for idle priority requests
+    q_idle: tokio::sync::Mutex<VecDeque<FetchRequest>>,
+
+    /// Map for managing inflight requests and their associated waiters
+    inflight: Arc<DashMap<String, Arc<Inflight>>>,
+
+    /// Observer for fetch functionality to send back net events
+    observer: Arc<dyn NetObserver + Send + Sync>,
+
+    /// Notifier to wake up the fetcher when a new request is submitted
+    wake: Notify,
+}
+
+impl Fetcher {
+    /// Creates a new `Fetcher` instance with the given configuration and optional observer.
+    pub fn new(config: FetcherConfig, observer: Option<Arc<dyn NetObserver + Send + Sync>>) -> Self {
+        let observer: Arc<dyn NetObserver + Send + Sync> =
+            observer.unwrap_or_else(|| Arc::new(crate::net::emitter::null_emitter::NullEmitter {}));
+
+        // Start default client
+        let client = reqwest::Client::builder()
+            .connection_verbose(true)
+            .http2_adaptive_window(true)
+            .connect_timeout(config.connect_timeout)
+            .timeout(config.req_timeout)
+            .use_rustls_tls()
+            .build()
+            .expect("reqwest client build failed");
+
+        Self {
+            client,
+            cfg: config.clone(),
+            global_slots: Arc::new(Semaphore::new(config.global_slots)),
+            per_origin: DashMap::new(),
+            q_high: tokio::sync::Mutex::new(VecDeque::new()),
+            q_norm: tokio::sync::Mutex::new(VecDeque::new()),
+            q_low: tokio::sync::Mutex::new(VecDeque::new()),
+            q_idle: tokio::sync::Mutex::new(VecDeque::new()),
+            inflight: Arc::new(DashMap::new()),
+            observer,
+            wake: Notify::new(),
+        }
+    }
+
+    /// Returns the origin of a URL as a string key.
+    fn origin_key(url: &Url) -> String {
+        // Use origin (scheme + host + port) as key
+        url.origin().ascii_serialization()
+    }
+
+    /// Pick the next request to process, using weighted round-robin across priority lanes.
+    /// There are probably better schedulers, but this is simple and effective.
+    fn pick_lane<'a>(
+        &'a self,
+        high: &'a mut VecDeque<FetchRequest>,
+        norm: &'a mut VecDeque<FetchRequest>,
+        low: &'a mut VecDeque<FetchRequest>,
+        idle: &'a mut VecDeque<FetchRequest>,
+        counter: &mut u8,
+    ) -> Option<FetchRequest> {
+        // Weighted round-robin: 8:4:2:1
+
+        let slot = *counter as usize;
+        *counter = (*counter + 1) % 15; // 8 + 4 + 2 + 1 = 15 slots
+
+        let try_pop = |q: &mut VecDeque<FetchRequest>| q.pop_front();
+
+        let pick = match slot {
+            0..=7 => try_pop(high)
+                .or_else(|| try_pop(norm))
+                .or_else(|| try_pop(low))
+                .or_else(|| try_pop(idle)),
+            8..=11 => try_pop(norm)
+                .or_else(|| try_pop(high))
+                .or_else(|| try_pop(low))
+                .or_else(|| try_pop(idle)),
+            12..=13 => try_pop(low)
+                .or_else(|| try_pop(norm))
+                .or_else(|| try_pop(high))
+                .or_else(|| try_pop(idle)),
+            _ => try_pop(idle)
+                .or_else(|| try_pop(low))
+                .or_else(|| try_pop(norm))
+                .or_else(|| try_pop(high)),
+        };
+
+        pick
+    }
+
+    /// Submit a fetch request to the appropriate priority lane.
+    pub async fn submit(&self, req: FetchRequest) {
+        log::debug!("Submitting fetch request: {:?}", req);
+        let mut lane = match req.priority {
+            Priority::High => self.q_high.lock().await,
+            Priority::Normal => self.q_norm.lock().await,
+            Priority::Low => self.q_low.lock().await,
+            Priority::Idle => self.q_idle.lock().await,
+        };
+        lane.push_back(req);
+
+        self.wake.notify_one();
+    }
+
+    /// Runs the fetcher, processing requests from the priority queues
+    pub async fn run(&self, mut shutdown: tokio::sync::watch::Receiver<bool>) {
+        let mut lane_counter: u8 = 0;
+
+        loop {
+            // Check for shutdown
+            if *shutdown.borrow() {
+                break;
+            }
+
+            // Pull next request (if any)
+            let next = {
+                let mut high = self.q_high.lock().await;
+                let mut norm = self.q_norm.lock().await;
+                let mut low = self.q_low.lock().await;
+                let mut idle = self.q_idle.lock().await;
+                self.pick_lane(&mut high, &mut norm, &mut low, &mut idle, &mut lane_counter)
+            };
+
+            // If none, wait for notifcation of new requests, or shutdown
+            let Some(mut req) = next else {
+                tokio::select! {
+                    _ = self.wake.notified() => {},
+                    _ = shutdown.changed() => {},
+                }
+                continue;
+            };
+
+            // Coalescing: if an identical request is in-flight, register and move on so we don't duplicate work
+            let key_opt = req.key_data.generate();
+            let key_str = match key_opt {
+                Some(key_str) => {
+                    // Found a key we can use for coalescing
+                    key_str
+                }
+                None => {
+                    // No key found we can use for coalescing. This can happen if we have non-safe requests like POST, PUT etc.
+                    // We must generate a unique one so this request is not coalesced with anything else.
+                    format!(
+                        "{} {} @{}",
+                        req.key_data.method,
+                        req.key_data.url,
+                        chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+                    )
+                }
+            };
+
+            let (inflight_entry, is_leader) = match self.inflight.entry(key_str.clone()) {
+                Entry::Occupied(entry) => (entry.get().clone(), false),
+                Entry::Vacant(v) => {
+                    let arc = Inflight::new();
+                    v.insert(arc.clone());
+                    (arc, true)
+                }
+            };
+
+            // Register this waiter to the shared Inflight.waiter
+            if let Some(tx) = req.reply.take() {
+                inflight_entry.waiter.register(tx, req.streaming).await;
+            }
+
+            // Escalate if this waiter needs streaming
+            if req.streaming {
+                inflight_entry
+                    .wants_streaming
+                    .store(true, Ordering::Relaxed);
+            }
+
+            // Followers are done; leader will spawn the fetch task
+            if !is_leader {
+                continue;
+            }
+
+            // Spawn a task to do the actual work
+            let client = self.client.clone();
+            let global = self.global_slots.clone();
+            let per_origin = self.per_origin.clone();
+            let cfg = self.cfg.clone();
+            let inflight = self.inflight.clone();
+            let key_str2 = key_str.clone();
+            let inflight_entry2 = inflight_entry.clone();
+            let observer_clone = self.observer.clone();
+            let mut shutdown_child = shutdown.clone();
+
+            let inflight_guard = InflightGuard::new(inflight.clone(), key_str2.clone());
+
+            let title = format!("Fetcher: {}", short_url(&req.key_data.url, 80));
+            let _ = spawn_named(&title, async move {
+                let origin = Fetcher::origin_key(&req.key_data.url);
+                let slots = per_origin
+                    .entry(origin.clone())
+                    .or_insert_with(|| Arc::new(Semaphore::new(per_origin_limit_for(&cfg, &req.key_data.url))))
+                    .clone();
+
+                let g = tokio::select! { p = global.acquire_owned() => Some(p), _ = shutdown_child.changed() => None };
+                if g.is_none() { return; } // guard will drop -> cleanup
+
+                let h = tokio::select! { p = slots.acquire_owned() => Some(p), _ = shutdown_child.changed() => None };
+                if h.is_none() { return; } // guard will drop -> cleanup
+
+                let should_stream = req.streaming || inflight_entry2.wants_streaming.load(Ordering::Relaxed);
+
+                // Perform the request
+                let result = if should_stream {
+                    perform_streaming(&client, observer_clone.clone(), &req, &cfg).await
+                } else {
+                    perform_buffered(
+                        &client,
+                        observer_clone.clone(),
+                        &req,
+                        cfg.read_idle_timeout,
+                        cfg.total_body_timeout,
+                    )
+                    .await
+                };
+
+                // Fanout to all listeners
+                inflight_entry2.waiter.finish(result).await;
+
+                // We can remove our inflight entry now
+                inflight.remove(&key_str2);
+
+                // Remove the guard
+                inflight_guard.remove();
+            });
+        }
+    }
+}
+
+// Choose per-origin limit based on scheme/alpn (rough heuristic here).
+fn per_origin_limit_for(cfg: &FetcherConfig, url: &Url) -> usize {
+    match url.scheme() {
+        // reqwest will use h2 when it can; safe cap
+        "http" | "https" => cfg.h2_per_origin,
+        _ => cfg.h1_per_origin,
+    }
+}
+
+/// Perform the actual HTTP request using reqwest.
+async fn perform_streaming(
+    client: &reqwest::Client,
+    observer: Arc<dyn NetObserver + Send + Sync>,
+    req: &FetchRequest,
+    cfg: &FetcherConfig,
+) -> FetchResult {
+    // Get the response top (headers + peek)
+    match fetch_response_top(
+        Arc::new(client.clone()),
+        req.key_data.url.clone(),
+        req.cancel.clone(),
+        observer.clone(),
+    )
+    .await
+    {
+        Ok(ResponseTop { meta, peek, mut reader }) => {
+            let shared = SharedBody::new(SHARED_MAX_CAPACITY);
+            let shared_arc = Arc::new(shared);
+            let shared_clone = shared_arc.clone();
+            let cancel_clone = req.cancel.clone();
+            let idle = cfg.read_idle_timeout;
+            let total_deadline = cfg.total_body_timeout.map(|d| Instant::now() + d);
+
+            tokio::spawn(async move {
+                let mut buf = BytesMut::with_capacity(16 * 1024);
+
+                loop {
+                    let total_left = total_deadline.map(|dl| dl.saturating_duration_since(Instant::now()));
+
+                    tokio::select! {
+                        // Stream cancelled
+                        _ = cancel_clone.cancelled() => {
+                            shared_clone.error(NetError::Cancelled("stream read from perform_streaming".into()));
+                            break;
+                        }
+                        // Total timeout (if any)
+                        _ = async {
+                            if let Some(rem) = total_left {
+                                sleep(rem).await;
+                            } else {
+                                futures::future::pending::<()>().await;
+                            }
+                        } => {
+                            shared_clone.error(NetError::Timeout("timeout".into()));
+                            break;
+                        }
+                        // Idle timeout, or read
+                        res = timeout(idle, reader.read_buf(&mut buf)) => {
+                            match res {
+                                Err(_) => {
+                                    // Timeout ocurred
+                                    shared_clone.error(NetError::Timeout("read idle timeout".into()));
+                                    break;
+                                }
+                                Ok(Ok(0)) => {
+                                    // Stream emptied.
+                                    if !buf.is_empty() {
+                                        let chunk = buf.split().freeze();
+                                        shared_clone.push(chunk);
+                                    }
+                                    // Send eof to the readers
+                                    shared_clone.finish();
+                                    break;
+                                },
+                                Ok(Ok(_)) => {
+                                    // Just send the chunk
+                                    let chunk = buf.split().freeze();
+                                    if !chunk.is_empty() {
+                                        shared_clone.push(chunk);
+                                    }
+                                },
+                                Ok(Err(e)) => {
+                                    // Error ocurred during reading
+                                    shared_clone.error(NetError::from_anyhow(e.into()));
+                                    break;
+                                },
+                            }
+                        }
+                    }
+                }
+            });
+
+            FetchResult::Stream {
+                meta,
+                peek,
+                shared: shared_arc,
+            }
+        }
+
+        Err(e) => FetchResult::Error(e),
+    }
+}
+
+
+/// Perform an HTTP request using buffered mode
+async fn perform_buffered(
+    // Reqwest client
+    client: &reqwest::Client,
+    // Observer to emit NetEvents to
+    observer: Arc<dyn NetObserver + Send + Sync>,
+    // Actual request
+    req: &FetchRequest,
+    // Max timeout between reads
+    read_idle_timeout: Duration,
+    // Total timeout
+    total_timeout: Option<Duration>,
+) -> FetchResult {
+    match fetch_response_complete(
+        Arc::new(client.clone()),
+        req.key_data.url.clone(),
+        req.cancel.clone(),
+        observer,
+        req.max_bytes,
+        read_idle_timeout,
+        total_timeout,
+    )
+    .await
+    {
+        Ok((meta, body)) => FetchResult::Buffered {
+            meta,
+            body: Bytes::from(body),
+        },
+        Err(e) => FetchResult::Error(e),
+    }
+}

--- a/src/net/io_runtime.rs
+++ b/src/net/io_runtime.rs
@@ -1,0 +1,186 @@
+use crate::net::fetcher::{Fetcher, FetcherConfig};
+use crate::net::types::FetchRequest;
+use crate::util::spawn_named;
+use std::sync::Arc;
+use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
+
+/// IoHandle is the handle that controls the IO thread.
+pub struct IoHandle {
+    // Channel to submit fetch requests
+    tx_submit: mpsc::UnboundedSender<FetchRequest>,
+    // Send "true" when we want to shut down the IO thread
+    shutdown_tx: watch::Sender<bool>,
+    // Join handle for shutdown sync
+    join_handle: Option<JoinHandle<()>>,
+}
+
+impl IoHandle {
+    // Even though we COULD send directly from the IoHandle, it's more likely that we
+    // send commands through a copy of the tx_submit that we send in the EngineContext to zones and
+    // later tabs.
+    pub fn submit(&self, req: FetchRequest) -> Result<(), ()> {
+        self.tx_submit.send(req).map_err(|_| ())
+    }
+
+    /// Shutdown the IO thread
+    pub async fn shutdown(mut self) {
+        let _ = self.shutdown_tx.send(true);
+
+        drop(self.tx_submit);
+
+        if let Some(jh) = self.join_handle.take() {
+            match jh.await {
+                Ok(()) => {}
+                Err(e) if e.is_cancelled() => {
+                    log::warn!("I/O driver task was cancelled during shutdown");
+                }
+                Err(e) if e.is_panic() => {
+                    log::error!("I/O driver task panicked during shutdown: {e:?}");
+                }
+                Err(e) => {
+                    log::warn!("I/O driver join error: {e:?}");
+                }
+            }
+        }
+    }
+
+    pub fn subscribe(&self) -> mpsc::UnboundedSender<FetchRequest> {
+        self.tx_submit.clone()
+    }
+}
+
+/// Spawns the IO thread and runs a single fetcher on top. If needed, we can expand this system to
+/// run multiple fetchers on different OS threads for instance, but most likely the fetching itself
+/// isn't the biggest bottleneck.
+pub fn spawn_io_thread(cfg: FetcherConfig) -> IoHandle {
+    let (tx_submit, mut rx_submit) = mpsc::unbounded_channel::<FetchRequest>();
+    let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+
+    let join_handle = spawn_named("I/O Thread", async move {
+        let fetcher = Arc::new(Fetcher::new(cfg, None));
+        let sched_f = fetcher.clone();
+        let sched_stop_rx = shutdown_rx.clone();
+
+        // Drive the scheduler
+        let join_handle = spawn_named("I/O Fetcher Scheduler", async move {
+            sched_f.run(sched_stop_rx).await;
+        });
+
+        // Pump submissions coming from other threads into the fetcher's queues
+        loop {
+            tokio::select! {
+                maybe_req = rx_submit.recv() => {
+                    match maybe_req {
+                        Some(req) => fetcher.submit(req).await,
+                        None => {
+                            // All producers have dropped. Signal shutdown
+                            break
+                        }
+                    }
+                }
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // wait until the scheduler is stopped
+        let _ = join_handle.await;
+    });
+
+    IoHandle {
+        tx_submit,
+        shutdown_tx,
+        join_handle: Some(join_handle),
+    }
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::{timeout, sleep};
+
+    fn test_cfg() -> FetcherConfig {
+        FetcherConfig {
+            global_slots: 2,
+            h1_per_origin: 2,
+            h2_per_origin: 2,
+            connect_timeout: Duration::from_millis(50),
+            req_timeout: Duration::from_millis(100),
+            read_idle_timeout: Duration::from_millis(100),
+            total_body_timeout: Some(Duration::from_millis(150)),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn driver_starts_and_shuts_down_cleanly() {
+        let cfg = test_cfg();
+        let handle = super::spawn_io_thread(cfg);
+
+        // Give the driver a moment to boot its internal scheduler
+        sleep(Duration::from_millis(10)).await;
+
+        // Shutdown should complete without panic/cancel
+        timeout(Duration::from_secs(2), handle.shutdown())
+            .await
+            .expect("shutdown timed out");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn multiple_subscribers_do_not_block_shutdown() {
+        let cfg = test_cfg();
+        let handle = super::spawn_io_thread(cfg);
+
+        // create a few clones of the submit handle
+        let s1 = handle.subscribe();
+        let s2 = handle.subscribe();
+        let s3 = handle.subscribe();
+
+        // drop the clones — the original sender stays inside IoHandle
+        drop(s1);
+        drop(s2);
+        drop(s3);
+
+        // ensure the runtime still shuts down promptly
+        timeout(Duration::from_secs(2), handle.shutdown())
+            .await
+            .expect("shutdown timed out");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_signal_stops_driver_even_without_submissions() {
+        let cfg = test_cfg();
+        let handle = super::spawn_io_thread(cfg);
+
+        // no submissions; just shut down
+        timeout(Duration::from_secs(2), handle.shutdown())
+            .await
+            .expect("shutdown timed out");
+    }
+
+    // NOTE:
+    // The following test documents the “all producers dropped” path. Because IoHandle
+    // owns the primary sender and doesn’t expose a way to drop it except via shutdown(),
+    // we simulate the state transition by (a) dropping an extra clone (producer)
+    // and (b) issuing shutdown. This ensures both branches are exercised over time.
+    #[tokio::test(flavor = "current_thread")]
+    async fn dropping_all_producers_plus_shutdown_is_clean() {
+        let cfg = test_cfg();
+        let handle = super::spawn_io_thread(cfg);
+
+        // extra producer
+        let s = handle.subscribe();
+        drop(s);
+
+        // trigger shutdown; driver should exit promptly
+        timeout(Duration::from_secs(2), handle.shutdown())
+            .await
+            .expect("shutdown timed out");
+    }
+}

--- a/src/net/loader.rs
+++ b/src/net/loader.rs
@@ -1,57 +1,100 @@
 //! High-level document loading utilities.
-//!
-//! Currently just wraps `net::fetch()` with cancellation support
-//! and a future hook point for cache/redirect/CSP/etc.
 
-use anyhow::Context;
-use tokio::sync::broadcast;
-use tokio_util::sync::CancellationToken;
+use bytes::Bytes;
+use http::HeaderMap;
 use url::Url;
-use crate::engine::types::{NavigationId, RequestId};
-use crate::events::EngineEvent;
-use crate::net::emitter::engine_event_emitter::EngineEventEmitter;
-use crate::net::{fetch, Response};
-use crate::net::types::{Initiator, ResourceKind};
+use crate::net::mime::MimeKind;
+use serde_json::Value as JsonValue;
 
-pub type DocumentLoadResult = Result<Response, anyhow::Error>;
+/// A parsed document, represented as a string for now
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Document(pub String);
 
-/// Load the main document for a top-level navigation.
-///
-/// - Honors `cancel` (returns `Err` if cancelled before completion)
-/// - `ignore_cache` is a future hook; currently unused here
-pub async fn load_main_document(
-    tab_id: crate::tab::TabId,
-    nav_id: NavigationId,
-    url: Url,
-    cancel: CancellationToken,
-    ignore_cache: bool, // reserved
-    event_tx: broadcast::Sender<EngineEvent>,
-    kind: ResourceKind,
-    initiator: Initiator,
-) -> DocumentLoadResult {
-    // Early cancellation check
-    if cancel.is_cancelled() {
-        anyhow::bail!("navigation cancelled before start");
-    }
-
-    let req_id = RequestId::new();
-
-    let emitter = EngineEventEmitter {
-        tab_id,
-        nav_id,
-        req_id,
-        event_tx,
-        kind,
-        initiator,
-    };
-
-    if !ignore_cache {
-        // We need to make sure we check the cache first before requesting data
-    }
-
-    let resp = fetch(url, cancel, Some(&emitter))
-        .await
-        .context("network fetch failed");
-
-    Ok(resp?)
+/// The resource that was loaded
+#[derive(Debug)]
+pub enum Resource {
+    /// HTML document
+    Html(Document),
+    /// JSON document
+    Json(JsonValue),
+    /// (raw) image
+    Image { bytes: Bytes, mime: String }, // raw bytes (decode lazily in UI)
+    /// Text content
+    Text { text: String, mime: String },  // e.g. text/plain, css, etc.
+    /// Binary content
+    Binary { bytes: Bytes, mime: String } // downloadable/hex viewer
 }
+
+/// Metadata about a loaded resource
+#[derive(Debug)]
+pub struct ResourceMeta {
+    /// Final URL that is loaded
+    pub final_url: Url,
+    /// MimeKind detected
+    pub mime: MimeKind,
+    /// Charset detected
+    pub charset: Option<String>,
+    /// Content length (if provided)
+    pub content_length: Option<u64>,
+    /// E-Tag
+    pub etag: Option<String>,
+    /// Last modifier
+    pub last_modified: Option<String>,
+    /// Headers
+    pub headers: HeaderMap,
+}
+
+/// The result of a (successful) navigation load
+#[derive(Debug)]
+pub struct NavigationOutput {
+    pub meta: ResourceMeta,
+    pub resource: Resource,
+}
+
+/// Result type for navigation operations
+pub type NavResult<T> = Result<T, NavigationError>;
+pub type ResourceLoadResult = NavResult<NavigationOutput>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum NavigationError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("network error: {0}")]
+    NetworkError(String),
+
+    #[error("io cancelled: {0}")]
+    Cancelled(String),
+
+    #[error("io timeout: {0}")]
+    Timeout(String),
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+//
+// /// Load the main document for a top-level navigation.
+// pub async fn load_main_document(
+//     tab_id: crate::tab::TabId,
+//     nav_id: NavigationId,
+//     url: Url,
+//     cancel: CancellationToken,
+//     ignore_cache: bool, // reserved
+//     event_tx: broadcast::Sender<EngineEvent>,
+//     kind: ResourceKind,
+//     initiator: Initiator,
+// ) -> ResourceLoadResult {
+//     // Early cancellation check
+//     if cancel.is_cancelled() {
+//         return Err(NavigationError::Cancelled("navigation cancelled before start".into()));
+//     }
+//
+//     let req_id = RequestId::new();
+//     let emitter = EngineEventEmitter { tab_id, nav_id, req_id, event_tx, kind, initiator };
+//
+//     if !ignore_cache {
+//         // We need to make sure we check the cache first before requesting data
+//     }
+//
+//     fetch_resource(nav_id, url, cancel, Some(&emitter)).await
+// }

--- a/src/net/mime.rs
+++ b/src/net/mime.rs
@@ -1,0 +1,33 @@
+/// Mime type classification
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MimeKind {
+    Html,
+    Json,
+    Image,
+    Text,
+    Binary,
+}
+
+// @TODO: ok for now.. we should use something like crate::mimetype_detector
+
+pub fn classify_mime(header: Option<&str>, sniff: Option<&[u8]>) -> MimeKind {
+    if let Some(ct) = header {
+        let ct = ct.to_ascii_lowercase();
+        if ct.starts_with("text/html") { return MimeKind::Html; }
+        if ct.starts_with("application/json") { return MimeKind::Json; }
+        if ct.starts_with("image/") { return MimeKind::Image; }
+        if ct.starts_with("text/") { return MimeKind::Text; }
+    }
+
+    // fallback sniff
+    if let Some(b) = sniff {
+        if b.starts_with(b"{") || b.starts_with(b"[") { return MimeKind::Json; }
+        if b.windows(6).any(|w| w.eq_ignore_ascii_case(b"<html>"))
+            || b.windows(15).any(|w| w.eq_ignore_ascii_case(b"<!doctype html>")) {
+            return MimeKind::Html;
+        }
+    }
+
+    MimeKind::Binary
+}
+

--- a/src/net/response.rs
+++ b/src/net/response.rs
@@ -1,22 +1,5 @@
 use http::HeaderMap;
 
-/// Minimal HTTP response model.
-///
-/// This struct represents a **fully buffered** HTTP response returned by the
-/// network layer. It contains the final URL (after redirects, if the client
-/// follows them), status code + reason, response headers, and the raw body bytes.
-///
-/// ## Notes
-/// - The body is stored as raw `Vec<u8>`. For text responses, convert with
-///   `String::from_utf8_lossy(&resp.body)` or similar. For JSON, parse with
-///   `serde_json::from_slice::<T>(&resp.body)`.
-/// - `headers` is an `http::HeaderMap`, which is **case-insensitive** for
-///   header names.
-/// - `status_text` is typically derived from the status code’s canonical
-///   reason phrase and may be `"Unknown"` for non-standard codes.
-///
-/// All fields reflect the **received** response as-is; no additional parsing
-/// or transformation is performed by this type.
 #[derive(Debug)]
 pub struct Response {
     /// Final URL of the response (after redirects, if any).

--- a/src/net/shared_body.rs
+++ b/src/net/shared_body.rs
@@ -1,0 +1,305 @@
+//! Bounded, fan-out body stream with per-subscriber queues and drop-on-lag policy.
+//!
+//! `SharedBody` lets one producer push `Bytes` while any number of subscribers
+//! receive them as a stream. Each subscriber has a bounded MPSC queue to cap
+//! memory usage. If a subscriber can't keep up, we drop that subscriber rather
+//! than stalling the producer (and other subscribers).
+//!
+//! Semantics:
+//! - `push(Bytes)`: best-effort, non-blocking; slow subscribers are removed.
+//! - `finish()`: closes all subscribers → they observe EOF (`None`) cleanly.
+//! - `error(NetError)`: broadcasts an error to all, then closes.
+//! - `subscribe_stream()`: returns a `Stream<Item = Result<Bytes, NetError>>`
+//!   that starts receiving future chunks from this point onward.
+//! - `combined_reader(peek, shared)`: convenient `AsyncRead` of `peek` then tail.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use bytes::Bytes;
+use futures_core::Stream;
+use futures_core::stream::BoxStream;
+use futures_util::{stream, StreamExt, TryStreamExt};
+use tokio::io::AsyncRead;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::io::StreamReader;
+use crate::net::types::NetError;
+
+#[derive(Clone)]
+pub struct SharedBody {
+    inner: Arc<Mutex<State>>,
+}
+
+struct State {
+    /// Active subscribers
+    subs: HashMap<u64, mpsc::Sender<Result<Bytes, NetError>>>,
+    /// Monotic id for subscribers
+    next_id: u64,
+    /// Limit on how many subscribers per queue are allowed
+    max_queue: usize,
+    /// If true, any additional push() is ignored. The stream is closed.
+    closed: bool,
+}
+
+impl SharedBody {
+    /// Create a new shared body with the given per-subscriber queue capacity.
+    pub fn new(max_queue: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(State {
+                subs: HashMap::new(),
+                next_id: 1,
+                max_queue,
+                closed: false,
+            }))
+        }
+    }
+
+    /// Push a chunk to all current subscribers (best-effort, non-blocking).
+    ///
+    /// Backpressure policy: if a subscriber's queue is full, we drop that subscriber
+    /// (and optionally try to send them a terminal error once). This keeps the producer
+    /// hot and bounds memory.
+    pub fn push(&self, chunk: Bytes) {
+        let (subs, mut to_remove) = {
+            let st = self.inner.lock().unwrap();
+            if st.closed {
+                return;
+            }
+            let subs: Vec<(u64, mpsc::Sender<_>)> =
+                st.subs.iter().map(|(id, tx)| (*id, tx.clone())).collect();
+
+            (subs, Vec::new())
+        };
+
+        for (id, tx) in subs {
+            match tx.try_send(Ok(chunk.clone())) {
+                Ok(()) => {},
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    to_remove.push(id);
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    to_remove.push(id);
+                }
+            }
+        }
+
+        // Remove any subscribers that have been removed
+        if !to_remove.is_empty() {
+            let mut st = self.inner.lock().unwrap();
+            for id in &to_remove {
+                st.subs.remove(id);
+            }
+        }
+    }
+
+    /// Broadcast an error to all subscribers and close the stream.
+    /// After this, `push()` is ignored and new subscribers won't be added.
+    pub fn error(&self, e: NetError) {
+        // drain and drop under lock; send error outside the lock
+        let senders: Vec<mpsc::Sender<Result<Bytes, NetError>>> = {
+            let mut st = self.inner.lock().unwrap();
+            if st.closed {
+                return;
+            }
+            st.closed = true;
+            st.subs.drain().map(|(_, tx)| tx).collect()
+        };
+
+        for tx in senders {
+            let _ = tx.try_send(Err(e.clone()));
+        }
+    }
+
+    /// Finish the stream cleanly (EOF): drop all senders so receivers see `None`.
+    pub fn finish(&self) {
+        // closed -> drop all senders so receivers see EOF
+        let _dropped: Vec<mpsc::Sender<Result<Bytes, NetError>>> = {
+            let mut st = self.inner.lock().unwrap();
+            if st.closed {
+                return;
+            }
+            st.closed = true;
+            st.subs.drain().map(|(_, tx)| tx).collect()
+        };
+
+        // dropping senders is enough; receivers yield None (EOF)
+    }
+
+    /// Subscribe to the stream **from this point onward**. If a subscriber subscribes to the
+    /// stream when already started, it will NOT receive any previous data.
+    ///
+    /// Returns a stream of `Result<Bytes, NetError>`. If the producer finishes, the
+    /// stream ends (`None`). If the producer errors, the next item is `Err(e)` and
+    /// then the stream ends.
+    pub fn subscribe_with_cap(&self, max_queue: usize) -> BoxStream<'static, Result<Bytes, NetError>> {
+        let (maybe_rx, id_opt) = {
+            let mut st = self.inner.lock().unwrap();
+            if st.closed {
+                return stream::empty::<Result<Bytes, NetError>>().boxed();
+            }
+
+            let (tx, rx) = mpsc::channel(max_queue);
+            let id = st.next_id;
+            st.next_id += 1;
+            st.subs.insert(id, tx);
+            (Some(rx), Some(id))
+        };
+
+        let rx = maybe_rx.unwrap();
+        let id = id_opt.unwrap();
+
+        SubStream {
+            id,
+            parent: self.inner.clone(),
+            inner: ReceiverStream::new(rx),
+        }.boxed()
+    }
+
+    // Subscribe with the configured per-subscriber queue capacity.
+    pub fn subscribe_stream(&self) -> BoxStream<'static, Result<Bytes, NetError>> {
+        let cap = {
+            let st = self.inner.lock().unwrap();
+            st.max_queue
+        };
+
+        self.subscribe_with_cap(cap)
+    }
+
+    /// Produce an `AsyncRead` that yields `peek` first, then the live tail bytes.
+    /// Useful for down-conversion to a single reader (e.g., for `read_to_end`).
+    pub fn combined_reader(peek: Vec<u8>, shared: Arc<SharedBody>) -> Pin<Box<dyn AsyncRead + Send>> {
+        let head = stream::iter([Ok::<Bytes, std::io::Error>(Bytes::from(peek))]);
+        let rest_stream = shared
+            .subscribe_stream()
+            .map_err(|e: NetError| e.to_io());
+
+        let combined = head.chain(rest_stream);
+        Box::pin(StreamReader::new(combined))
+    }
+}
+
+/// Per-subscriber stream that auto-unregisters on drop.
+struct SubStream {
+    id: u64,
+    parent: Arc<Mutex<State>>,
+    inner: ReceiverStream<Result<Bytes, NetError>>,
+}
+
+impl Stream for SubStream {
+    type Item = Result<Bytes, NetError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).poll_next(cx)
+    }
+}
+
+impl Drop for SubStream {
+    fn drop(&mut self) {
+        if let Ok(mut st)= self.parent.lock() {
+            st.subs.remove(&self.id);
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shared_body_broadcasts_and_finishes() {
+        let sb = SharedBody::new(8);
+
+        let mut s1 = sb.subscribe_stream();
+        let mut s2 = sb.subscribe_stream();
+
+        sb.push(Bytes::from_static(b"hello"));
+        sb.push(Bytes::from_static(b" world"));
+        sb.finish();
+
+        // s1 sees both chunks then EOF (None)
+        let a1 = s1.next().await.unwrap().unwrap();
+        let a2 = s1.next().await.unwrap().unwrap();
+        let expected1: &[u8] = b"hello";
+        let expected2: &[u8] = b" world";
+        assert_eq!((&a1[..], &a2[..]), (expected1, expected2));
+        assert!(s1.next().await.is_none());
+
+        // s2 sees both chunks then EOF
+        let b1 = s2.next().await.unwrap().unwrap();
+        let b2 = s2.next().await.unwrap().unwrap();
+        let expected1: &[u8] = b"hello";
+        let expected2: &[u8] = b" world";
+        assert_eq!((&b1[..], &b2[..]), (expected1, expected2));
+        assert!(s2.next().await.is_none());
+    }
+
+    // This test ensures that a slow subscriber is dropped when it can't
+    // keep up with the producer.
+    #[tokio::test(flavor = "current_thread")]
+    async fn shared_body_drops_slow_subscriber() {
+        // Small per-sub queue to force lag quickly. Only one item can be buffered.
+        let sb = SharedBody::new(1);
+
+        // Slow stream will read "slowly"
+        let mut slow = sb.subscribe_stream();
+        // Fast stream will read "quickly" (ie: we read before pushing more)
+        let mut fast = sb.subscribe_stream();
+
+        // Push first chunk; both get it buffered.
+        sb.push(Bytes::from_static(b"A"));
+
+        // Fast stream reads the 'A' quickly
+        let fa = fast.next().await.unwrap().unwrap();
+
+        // Fast is drained. Slow is full and thus dropped
+        sb.push(Bytes::from_static(b"B"));
+
+        // Consume 'B' from fast
+        let fb = fast.next().await.unwrap().unwrap();
+
+        // Slow should get 'A' but not 'B' (it was dropped)
+        let first = slow.next().await.unwrap();
+        assert!(first.is_ok());
+        let tail = slow.next().await; // None or Err
+        assert!(tail.is_none() || tail.unwrap().is_err());
+
+        // Push third chunk; There is no more slow subscriber, only fast.
+        sb.push(Bytes::from_static(b"C"));
+
+        // fast should get the remaining 'C'
+        let fc = fast.next().await.unwrap().unwrap();
+
+        // Fast should have all three chunks
+        let exp1: &[u8]  = b"A";
+        let exp2: &[u8]  = b"B";
+        let exp3: &[u8]  = b"C";
+        assert_eq!((&fa[..], &fb[..], &fc[..]), (exp1, exp2, exp3));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn combined_reader_yields_peek_then_tail() {
+        let sb = SharedBody::new(8);
+        let sb2 = sb.clone();
+
+        let peek = b"PEEK-".to_vec();
+
+        // write tail in background
+        tokio::spawn(async move {
+            sb2.push(Bytes::from_static(b"TAIL1"));
+            sb2.push(Bytes::from_static(b"TAIL2"));
+            sb2.finish();
+        });
+
+        // use the static helper you defined
+        let mut reader = SharedBody::combined_reader(peek, Arc::new(sb));
+
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).await.unwrap();
+        assert_eq!(&out[..], b"PEEK-TAIL1TAIL2");
+    }
+}

--- a/src/net/types.rs
+++ b/src/net/types.rs
@@ -1,9 +1,139 @@
+use bytes::Bytes;
+use std::fmt::{Debug, Display};
+use std::pin::Pin;
+use std::sync::Arc;
+use http::{header, HeaderMap, Method};
+use tokio::io::{AsyncRead, ReadBuf};
+use tokio_util::sync::CancellationToken;
+use url::Url;
+use crate::net::shared_body::SharedBody;
+use crate::net::utils::{normalize_url, short_hash, BytesAsyncReader};
+use crate::tab::TabId;
+
+#[derive(Debug, Clone, Copy)]
+pub enum BodyDecode {
+    /// Automatically decode the body
+    Auto,
+    /// Return the body as-is
+    Raw,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum FetchMode {
+    // fetch the top of the resource
+    TopOnly,
+    // fetch the complete resource
+    Complete,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ResourceKindHint {
+    MainDocument,
+    SubResource,
+}
+
+pub struct BodyStream {
+    /// Inner reader
+    inner: Pin<Box<dyn AsyncRead + Send + 'static>>,
+    /// Content length (if known)
+    pub len: Option<u64>,
+    /// True when the stream is seekable (most often not, unless it's backed by a memory buffer)
+    pub is_seekable: bool,
+    /// Can be cloned to create a new independent stream starting at the beginning
+    pub clonable: bool,
+}
+
+impl Debug for BodyStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BodyStream")
+            .field("len", &self.len)
+            .field("is_seekable", &self.is_seekable)
+            .field("clonable", &self.clonable)
+            .finish()
+    }
+}
+
+impl BodyStream {
+    pub fn new(inner: Pin<Box<dyn AsyncRead + Send + 'static>>, len: Option<u64>) -> Self {
+        Self {
+            inner,
+            len,
+            is_seekable: false,
+            clonable: false,
+        }
+    }
+
+    /// Converts a series of bytes into a body stream
+    pub fn from_bytes(bytes: Bytes) -> Self {
+        let len = bytes.len() as u64;
+        let reader = Box::pin(BytesAsyncReader { data: bytes, pos: 0 });
+        Self {
+            inner: reader,
+            len: Some(len),
+            is_seekable: true,  // It's a buffer so we can seek it
+            clonable: true,     // It's a buffer so we can clone it
+        }
+    }
+}
+
+impl AsyncRead for BodyStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        self.inner.as_mut().poll_read(cx, buf)
+    }
+}
+
+/// Metadata returned by the FetchResult
+#[derive(Clone, Debug)]
+pub struct FetchResultMeta {
+    /// Final URL after redirects
+    pub final_url: Url,
+    /// HTTP status code
+    pub status: u16,
+    /// HTTP status reason phrase
+    pub status_text: String,
+    /// Response headers
+    pub headers: HeaderMap,
+    /// Length of the content (if known from headers)
+    pub content_length: Option<u64>,
+    /// First bytes of the response body, for MIME sniffing etc
+    pub peek: Vec<u8>,
+    /// True if the response has a body (e.g. HEAD requests do not)
+    pub has_body: bool,
+}
+
+/// Priority of the scheduled request. Documents usually have high priority, while images have low.
+/// Currently, the scheduler uses a round-robin system to load resources
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum Priority {
+    High,
+    Normal,
+    Low,
+    Idle,
+}
+
+impl Display for Priority {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Priority::High => "High",
+            Priority::Normal => "Normal",
+            Priority::Low => "Low",
+            Priority::Idle => "Idle",
+        };
+
+        f.write_str(s)
+    }
+}
+
 /// Defines the different resource types that are available for loading
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum ResourceKind {
     Document,
     Stylesheet,
-    Script,
+    Script { blocking: bool },
     Image,
     Font,
     Media,
@@ -11,6 +141,182 @@ pub enum ResourceKind {
     Fetch,
     WebSocket,
     Other,
+}
+
+/// A fetch key data is a key that is used to find out if two requests want to fetch the same resource.
+/// If this is true, the requests are bundled so only once the resource will be fetched.
+#[derive(Debug, Clone)]
+pub struct FetchKeyData {
+    pub url: Url,
+    pub method: Method,
+    pub headers: HeaderMap,
+}
+
+impl Display for FetchKeyData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.url)
+    }
+}
+
+impl FetchKeyData {
+    pub fn new(url: Url) -> Self {
+        Self {
+            url,
+            method: Method::GET,
+            headers: HeaderMap::new(),
+        }
+    }
+
+    /// Generates a key for coalescing in-flight requests based on the request's method, URL, and headers.
+    pub fn generate(&self) -> Option<String> {
+        match self.method {
+            Method::GET | Method::HEAD => {
+                // Only allow safe methods for coalescing
+            }
+            _ => return None,
+        }
+
+        let url = normalize_url(&self.url);
+        let h = &self.headers;
+
+        let range = h
+            .get(header::RANGE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        let accept = h
+            .get(header::ACCEPT)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        let accept_enc = h
+            .get(header::ACCEPT_ENCODING)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        let accept_lang = h
+            .get(header::ACCEPT_LANGUAGE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        let auth_hash = h
+            .get(header::AUTHORIZATION)
+            .map(|v| format!("{:x}", short_hash(v.as_bytes())))
+            .unwrap_or_default();
+
+        let cookie_hash = h
+            .get(header::COOKIE)
+            .map(|v| format!("{:x}", short_hash(v.as_bytes())))
+            .unwrap_or_default();
+
+        Some(format!(
+            "M={};U={};R={};A={};AL={};AE={};Auth={};C={}",
+            self.method, url, range, accept, accept_lang, accept_enc, auth_hash, cookie_hash
+        ))
+    }
+}
+
+/// A fetch request defines what needs to be fetched, how and where to send the result to
+#[derive(Debug)]
+pub struct FetchRequest {
+    /// Key data identifying the resource to fetch
+    pub key_data: FetchKeyData,
+    /// Priority of this request
+    pub priority: Priority,
+    /// Who initiated this request
+    pub initiator: Initiator,
+    /// What kind of resource is being fetched
+    pub kind: ResourceKind,
+    // Which Tab is asking for this resource
+    pub tab_id: TabId,
+    // whether to stream or buffer
+    pub streaming: bool,
+    /// Auto decode the request (if for instance, gzipped), or pass directly through to the caller
+    pub auto_decode: bool,
+    /// Maximum amount of (buffered) bytes we can fetch
+    pub max_bytes: Option<usize>,
+    /// Cancellation token
+    pub cancel: CancellationToken,
+    // Reply channel
+    pub reply: Option<tokio::sync::oneshot::Sender<FetchResult>>,
+}
+
+/// FetchResult defines the resource response. Either a stream or buffered response are possible
+#[derive(Clone)]
+pub enum FetchResult {
+    /// Buffered response body
+    Buffered { meta: FetchResultMeta, body: Bytes },
+    /// Streamed response body
+    Stream { meta: FetchResultMeta, peek: Vec<u8>, shared: Arc<SharedBody> },
+    /// Error
+    Error(NetError),
+}
+
+impl Debug for FetchResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FetchResult::Stream { meta, .. } => f
+                .debug_struct("FetchResult::Stream")
+                .field("meta", meta)
+                .finish(),
+            FetchResult::Buffered { meta, body } => f
+                .debug_struct("FetchResult::Buffered")
+                .field("meta", meta)
+                .field("body_len", &body.len())
+                .finish(),
+            FetchResult::Error(e) => f.debug_tuple("FetchResult::Error").field(e).finish(),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error, Clone)]
+pub enum NetError {
+    // Direct reqwest errors
+    #[error("net error: reqwest: {0}")]
+    Reqwest(#[from] Arc<reqwest::Error>),
+
+    // Redirection errors
+    #[error("net error: redirect: {0}")]
+    Redirect(Arc<anyhow::Error>),
+
+    // direct I/O errors
+    #[error("net error: I/O: {0}")]
+    Io(#[from] Arc<std::io::Error>),
+
+    /// Cancelled by the user
+    #[error("net error: cancelled: {0}")]
+    Cancelled(String),
+
+    // Reading errors
+    #[error(transparent)]
+    Read(Arc<anyhow::Error>),
+
+    // Any other kind of errors
+    #[error(transparent)]
+    Other(Arc<anyhow::Error>),
+
+    // Timeout errors
+    #[error("net error: timeout: {0}")]
+    Timeout(String),
+}
+
+// impl From<reqwest::Error> for NetError {
+//     fn from(e: reqwest::Error) -> Self {
+//         NetError::Reqwest(Arc::new(e))
+//     }
+// }
+//
+impl From<std::io::Error> for NetError {
+    fn from(e: std::io::Error) -> Self {
+        NetError::Io(Arc::new(e))
+    }
+}
+
+impl NetError {
+    pub fn to_io(&self) -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::Other, format!("{}", self))
+    }
+
+    pub fn from_anyhow(e: anyhow::Error) -> Self {
+        Self::Read(Arc::new(e))
+    }
 }
 
 /// Defines who initiated the resource load
@@ -26,4 +332,133 @@ pub enum Initiator {
     CSS,
     /// Other undefined type of initiator
     Other,
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::header;
+    use tokio::io::AsyncReadExt;
+
+    fn dummy_meta() -> FetchResultMeta {
+        FetchResultMeta {
+            final_url: Url::parse("http://example.org/").unwrap(),
+            status: 200,
+            status_text: "OK".into(),
+            headers: HeaderMap::new(),
+            content_length: None,
+            peek: Vec::new(),
+            has_body: true,
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn bodystream_from_bytes_reads_all() {
+        let data = Bytes::from_static(b"hello world");
+        let mut s = BodyStream::from_bytes(data.clone());
+        assert_eq!(s.len, Some(11));
+        assert!(s.is_seekable);
+        assert!(s.clonable);
+
+        let mut out = Vec::new();
+        s.read_to_end(&mut out).await.unwrap();
+        assert_eq!(&out[..], &data[..]);
+
+        // further reads are EOF
+        let mut buf = [0u8; 8];
+        let n = s.read(&mut buf).await.unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn fetch_key_generate_get_and_headers() {
+        let mut fk = FetchKeyData::new(Url::parse("https://example.org/a/b#frag").unwrap());
+        // set method GET (already default) and headers that impact the key
+        fk.headers.insert(header::RANGE, "bytes=0-99".parse().unwrap());
+        fk.headers.insert(header::ACCEPT, "text/html".parse().unwrap());
+        fk.headers.insert(header::ACCEPT_LANGUAGE, "en-US".parse().unwrap());
+        fk.headers.insert(header::ACCEPT_ENCODING, "gzip".parse().unwrap());
+        fk.headers.insert(header::AUTHORIZATION, "Bearer abc".parse().unwrap());
+        fk.headers.insert(header::COOKIE, "a=1; b=2".parse().unwrap());
+
+        let key = fk.generate().expect("GET should produce a key");
+
+        // Build the expected string using the same helpers to avoid drift.
+        let url_norm = normalize_url(&fk.url);
+        let auth_hash = format!("{:x}", short_hash(b"Bearer abc"));
+        let cookie_hash = format!("{:x}", short_hash(b"a=1; b=2"));
+        let expected = format!(
+            "M={};U={};R={};A={};AL={};AE={};Auth={};C={}",
+            fk.method, url_norm, "bytes=0-99", "text/html", "en-US", "gzip", auth_hash, cookie_hash
+        );
+
+        assert_eq!(key, expected);
+        assert!(key.starts_with("M=GET;U=https://example.org/a/b"));
+        assert!(!key.contains("#frag")); // fragment must be stripped
+    }
+
+    #[test]
+    fn fetch_key_generate_post_is_none() {
+        let mut fk = FetchKeyData::new(Url::parse("https://example.org/").unwrap());
+        fk.method = Method::POST;
+        assert!(fk.generate().is_none());
+    }
+
+    #[test]
+    fn priority_display_is_stable() {
+        assert_eq!(format!("{}", Priority::High), "High");
+        assert_eq!(format!("{}", Priority::Normal), "Normal");
+        assert_eq!(format!("{}", Priority::Low), "Low");
+        assert_eq!(format!("{}", Priority::Idle), "Idle");
+    }
+
+    #[test]
+    fn neterror_helpers_work() {
+        // to_io
+        let io = NetError::Timeout("oops".into()).to_io();
+        assert_eq!(io.kind(), std::io::ErrorKind::Other);
+        assert!(io.to_string().to_lowercase().contains("timeout"));
+
+        // from_anyhow
+        let ne = NetError::from_anyhow(anyhow::anyhow!("boom"));
+        match ne {
+            NetError::Read(_) => {}
+            _ => panic!("expected NetError::Read"),
+        }
+    }
+
+    #[test]
+    fn fetchresult_debug_and_clone() {
+        let meta = dummy_meta();
+        let body = Bytes::from_static(b"DATA");
+        let r1 = FetchResult::Buffered { meta: meta.clone(), body: body.clone() };
+
+        let dbg = format!("{r1:?}");
+        assert!(dbg.contains("FetchResult::Buffered"));
+        assert!(dbg.contains("body_len: 4"));
+        assert!(dbg.contains("status: 200"));
+
+        // clone keeps content
+        let r2 = r1.clone();
+        match r2 {
+            FetchResult::Buffered { meta: m, body: b } => {
+                assert_eq!(m.status, 200);
+                assert_eq!(&b[..], b"DATA");
+            }
+            _ => panic!("expected buffered"),
+        }
+    }
+
+    #[test]
+    fn fetchresult_stream_variant_compiles() {
+        // just ensure the type is constructible (no runtime path needed here)
+        let meta = dummy_meta();
+        let shared = Arc::new(SharedBody::new(8));
+        let _r = FetchResult::Stream {
+            meta,
+            peek: b"PEEK".to_vec(),
+            shared,
+        };
+    }
 }

--- a/src/net/utils.rs
+++ b/src/net/utils.rs
@@ -1,0 +1,310 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::pin::Pin;
+use std::sync::Arc;
+use bytes::Bytes;
+use tokio::io::{AsyncReadExt, ReadBuf};
+use tokio::sync::{oneshot, Mutex};
+use url::Url;
+use crate::net::SharedBody;
+use crate::net::types::{FetchResult, FetchResultMeta, NetError};
+
+// Simple waiter for coalescing responses. If a fetcher detects we are requesting the same resources
+// that is already queued, we add them to the waiter for that request, so the request will fetch the
+// resource only once.
+#[derive(Default)]
+pub struct Waiter {
+    listeners: Mutex<Vec<(bool, oneshot::Sender<FetchResult>)>>,
+}
+
+impl Waiter {
+    pub(crate) fn new_arc() -> Arc<Waiter> {
+        Arc::new(Waiter::new())
+    }
+}
+
+impl Waiter {
+    pub fn new() -> Self {
+        Self {
+            listeners: Mutex::new(Vec::new())
+        }
+    }
+
+    /// Register a consumer for this waiter. We need to know if the consumer is streaming or not.
+    pub async fn register(&self, tx: oneshot::Sender<FetchResult>, wants_streaming: bool) {
+        self.listeners.lock().await.push((wants_streaming, tx))
+    }
+
+    /// Process the fetch result with the listeners.
+    pub async fn finish(self: &Arc<Self>, result: FetchResult) {
+        let mut ls = self.listeners.lock().await;
+
+        match result {
+            FetchResult::Buffered { meta, body } => {
+                let res = FetchResult::Buffered { meta: meta.clone(), body: body.clone() };
+                for (_, tx) in ls.drain(..) {
+                    let _ = tx.send(res.clone());
+                }
+            }
+            FetchResult::Stream { meta, peek, shared } => {
+                let mut streaming_ls = Vec::new();
+                let mut buffered_ls = Vec::new();
+                while let Some((wants_stream, tx)) = ls.pop() {
+                    if wants_stream {
+                        streaming_ls.push(tx);
+                    } else {
+                        buffered_ls.push(tx);
+                    }
+                }
+
+                // Send the stream to all the streaming listeners
+                for tx in streaming_ls {
+                    let res = FetchResult::Stream { meta: meta.clone(), peek: peek.clone(), shared: shared.clone() };
+                    let _ = tx.send(res);
+                }
+
+                // Send the stream as buffered to all the buffered listeners
+                if !buffered_ls.is_empty() {
+                    let buffered_res = stream_to_bytes(meta.clone(), peek, shared).await;
+                    for tx in buffered_ls {
+                        let _ = tx.send(buffered_res.clone());
+                    }
+                }
+            }
+            FetchResult::Error(e) => {
+                let res = FetchResult::Error(e.clone());
+                for (_, tx) in ls.drain(..) {
+                    let _ = tx.send(res.clone());
+                }
+            }
+        }
+    }
+}
+
+/// Convert a streaming body a buffered fetchresult by reading it to the end.
+/// This could be more efficient with allocations probably.
+async fn stream_to_bytes(
+    meta: FetchResultMeta,
+    peek: Vec<u8>,
+    shared: Arc<SharedBody>,
+) -> FetchResult {
+    // Allocate for at least peek buffer, plus some additional to start the streaming
+    let mut out = Vec::with_capacity(peek.len() + 8192);
+
+    let mut reader = SharedBody::combined_reader(peek, shared);
+    if let Err(e) = reader.read_to_end(&mut out).await {
+        return FetchResult::Error(NetError::Io(Arc::new(e)));
+    }
+
+    FetchResult::Buffered { meta, body: Bytes::from(out) }
+}
+
+/// Normalizes a URL by removing its fragment and returning it as a string.
+pub fn normalize_url(u: &Url) -> String {
+    let mut u = u.clone();
+    u.set_fragment(None);
+    u.as_str().to_string()
+}
+
+/// Computes a short hash for a given byte slice.
+pub fn short_hash(bytes: &[u8]) -> u64 {
+    let mut h = DefaultHasher::new();
+    bytes.hash(&mut h);
+    h.finish()
+}
+
+/// Create a short url (with ... truncated)
+pub fn short_url(u: &Url, max: usize) -> String {
+    let s = u.as_str();
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max])
+    }
+}
+
+
+// Small async reader for BodyStream::from_bytes
+pub struct BytesAsyncReader {
+    pub data: Bytes,
+    pub pos: usize,
+}
+
+impl tokio::io::AsyncRead for BytesAsyncReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let remaining = self.data.len().saturating_sub(self.pos);
+        if remaining == 0 {
+            return std::task::Poll::Ready(Ok(())); // EOF
+        }
+        let to_copy = std::cmp::min(remaining, buf.remaining());
+        let end = self.pos + to_copy;
+        buf.put_slice(&self.data[self.pos..end]);
+        self.pos = end;
+        std::task::Poll::Ready(Ok(()))
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::net::shared_body::SharedBody;
+    use tokio::io::AsyncReadExt;
+    use tokio::time::{sleep, Duration};
+
+    fn dummy_meta() -> FetchResultMeta {
+        FetchResultMeta {
+            final_url: Url::parse("http://example.org/").unwrap(),
+            status: 200,
+            status_text: "OK".into(),
+            headers: http::HeaderMap::new(),
+            content_length: None,
+            peek: Vec::new(),
+            has_body: true,
+        }
+    }
+
+    #[test]
+    fn normalize_url_strips_fragment() {
+        let u = Url::parse("https://example.org/a/b#frag").unwrap();
+        assert_eq!(normalize_url(&u), "https://example.org/a/b");
+    }
+
+    #[test]
+    fn short_hash_differs_for_diff_inputs() {
+        let a = short_hash(b"abc");
+        let b = short_hash(b"abd");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn short_url_truncates() {
+        let u = Url::parse("https://example.org/very/long/path/here").unwrap();
+        let s = short_url(&u, 16);
+        assert!(s.ends_with("..."));
+        assert!(s.len() <= 19); // 16 + "..."
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn bytes_async_reader_reads_all() {
+        let data = Bytes::from_static(b"hello world");
+        let mut r = BytesAsyncReader { data, pos: 0 };
+        let mut out = Vec::new();
+        r.read_to_end(&mut out).await.unwrap();
+        assert_eq!(&out[..], b"hello world");
+        // second read should be EOF (0 bytes)
+        let n = r.read(&mut [0u8; 8]).await.unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn waiter_finishes_buffered_to_all() {
+        let waiter = Waiter::new_arc();
+        let (tx1, rx1) = oneshot::channel();
+        let (tx2, rx2) = oneshot::channel();
+        waiter.register(tx1, false).await; // buffered
+        waiter.register(tx2, true).await;  // streaming-flag shouldn't matter for Buffered result
+
+        let body = Bytes::from_static(b"BODY");
+        let meta = dummy_meta();
+        waiter
+            .finish(FetchResult::Buffered {
+                meta: meta.clone(),
+                body: body.clone(),
+            })
+            .await;
+
+        let r1 = rx1.await.unwrap();
+        let r2 = rx2.await.unwrap();
+        match r1 {
+            FetchResult::Buffered { meta: m, body: b } => {
+                assert_eq!(m.status, 200);
+                assert_eq!(&b[..], b"BODY");
+            }
+            _ => panic!("expected buffered"),
+        }
+        match r2 {
+            FetchResult::Buffered { meta: m, body: b } => {
+                assert_eq!(m.status, 200);
+                assert_eq!(&b[..], b"BODY");
+            }
+            _ => panic!("expected buffered"),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn waiter_stream_is_fanned_out_and_buffered_followers_convert() {
+        let (tx_stream, rx_stream) = oneshot::channel();
+        let (tx_buf, rx_buf) = oneshot::channel();
+
+        let waiter = Waiter::new_arc();
+        waiter.register(tx_stream, true).await; // wants streaming
+        waiter.register(tx_buf, false).await;   // wants buffered
+
+        // Prepare shared body that will receive tail bytes shortly
+        let shared = Arc::new(SharedBody::new(8));
+        let shared_writer = shared.clone();
+
+        // Push tail asynchronously after a short delay
+        tokio::spawn(async move {
+            // small delay makes sure finish() is waiting on stream_to_bytes
+            sleep(Duration::from_millis(10)).await;
+            shared_writer.push(Bytes::from_static(b"TAIL1"));
+            shared_writer.push(Bytes::from_static(b"TAIL2"));
+            shared_writer.finish();
+        });
+
+        let meta = dummy_meta();
+        let peek = b"PEEK-".to_vec();
+
+        // Finish with a Stream result (leader would produce this)
+        waiter
+            .finish(FetchResult::Stream {
+                meta: meta.clone(),
+                peek: peek.clone(),
+                shared: shared.clone(),
+            })
+            .await;
+
+        // Streaming listener should get Stream
+        let r_stream = rx_stream.await.unwrap();
+        match r_stream {
+            FetchResult::Stream { meta: m, peek: p, .. } => {
+                assert_eq!(m.status, 200);
+                assert_eq!(&p[..], b"PEEK-");
+            }
+            _ => panic!("expected stream"),
+        }
+
+        // Buffered listener should get the concatenation of peek + tail
+        let r_buf = rx_buf.await.unwrap();
+        match r_buf {
+            FetchResult::Buffered { meta: m, body } => {
+                assert_eq!(m.status, 200);
+                assert_eq!(&body[..], b"PEEK-TAIL1TAIL2");
+            }
+            _ => panic!("expected buffered"),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn waiter_propagates_error() {
+        let waiter = Waiter::new_arc();
+        let (tx1, rx1) = oneshot::channel();
+        let (tx2, rx2) = oneshot::channel();
+        waiter.register(tx1, false).await;
+        waiter.register(tx2, true).await;
+
+        waiter
+            .finish(FetchResult::Error(NetError::Cancelled("boom".into())))
+            .await;
+
+        let r1 = rx1.await.unwrap();
+        let r2 = rx2.await.unwrap();
+        matches!(r1, FetchResult::Error(_));
+        matches!(r2, FetchResult::Error(_));
+    }
+}

--- a/src/render/backends/cairo.rs
+++ b/src/render/backends/cairo.rs
@@ -17,8 +17,12 @@ impl CairoBackend {
 }
 
 impl RenderBackend for CairoBackend {
+    fn name(&self) -> &str {
+        "cairo"
+    }
+
     /// Will create a new Cairo surface with the given size and present mode.
-    fn create_surface(&self, size: SurfaceSize, present: PresentMode) -> Result<Box<dyn ErasedSurface>> {
+    fn create_surface(&self, size: SurfaceSize, present: PresentMode) -> Result<Box<dyn ErasedSurface + Send>> {
         Ok(Box::new(CairoSurface::new(size, present)?))
     }
 
@@ -78,6 +82,7 @@ impl RenderBackend for CairoBackend {
                         text,
                         size,
                         color,
+                        ..
                     } => {
                         // Draw text at the specified position with the specified size and color.
                         cr.set_source_rgba(

--- a/src/render/backends/vello/font_cache.rs
+++ b/src/render/backends/vello/font_cache.rs
@@ -44,7 +44,7 @@ impl FontCache {
     }
 
     pub fn insert(&mut self, name: &str, resolved_name: &str, font: Font) {
-        println!("Caching font {} as {}", name, resolved_name);
+        //println!("Caching font {} as {}", name, resolved_name);
         self.fonts.insert(name.to_string(), font);
         self.resolved_names
             .insert(name.to_string(), resolved_name.to_string());

--- a/src/tests/shared_body_tests.rs
+++ b/src/tests/shared_body_tests.rs
@@ -1,0 +1,112 @@
+use std::sync::Arc;
+use bytes::{Bytes, BytesMut};
+use futures_util::StreamExt;
+use tokio::io::AsyncReadExt;
+
+use gosub_engine::net::shared_body::SharedBody; // adjust path to your crate
+use gosub_engine::net::types::{NetError, FetchResult, FetchResultMeta};
+
+#[tokio::test(flavor = "current_thread")]
+async fn shared_body_broadcasts_and_finishes() {
+    let sb = SharedBody::new(8);
+
+    let mut s1 = sb.subscribe_stream();
+    let mut s2 = sb.subscribe_stream();
+
+    sb.push(Bytes::from_static(b"hello"));
+    sb.push(Bytes::from_static(b" world"));
+    sb.finish();
+
+    let a1 = s1.next().await.unwrap().unwrap();
+    let a2 = s1.next().await.unwrap().unwrap();
+    assert_eq!(&a1[..], b"hello");
+    assert_eq!(&a2[..], b" world");
+    assert!(s1.next().await.is_none()); // EOF
+
+    let b1 = s2.next().await.unwrap().unwrap();
+    let b2 = s2.next().await.unwrap().unwrap();
+    assert_eq!(&b1[..], b"hello");
+    assert_eq!(&b2[..], b" world");
+    assert!(s2.next().await.is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn shared_body_drops_slow_subscriber() {
+    // queue size 1 => easy to overflow
+    let sb = SharedBody::new(1);
+
+    let mut slow = sb.subscribe_stream();
+    let mut fast = sb.subscribe_stream();
+
+    // Fill, then overflow -> slow will be dropped with lag error
+    sb.push(Bytes::from_static(b"A"));
+    sb.push(Bytes::from_static(b"B")); // this should drop 'slow'
+    sb.push(Bytes::from_static(b"C"));
+
+    // slow consumes first chunk, then should receive an error or end
+    let first = slow.next().await.unwrap();
+    assert!(first.is_ok());
+    let tail = slow.next().await;
+    assert!(tail.is_none() || tail.unwrap().is_err(), "slow sub should be dropped");
+
+    // fast should get all chunks after subscribe
+    let fa = fast.next().await.unwrap().unwrap();
+    let fb = fast.next().await.unwrap().unwrap();
+    let fc = fast.next().await.unwrap().unwrap();
+    assert_eq!((&fa[..], &fb[..], &fc[..]), (b"A", b"B", b"C"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn combined_reader_orders_peek_then_tail() {
+    let sb = SharedBody::new(8);
+    // tail comes in later
+    let sb2 = sb.clone();
+
+    let peek = b"PEEK-".to_vec();
+    let mut reader = sb.combined_reader(peek.clone());
+
+    // pump some tail
+    sb2.push(Bytes::from_static(b"TAIL1"));
+    sb2.push(Bytes::from_static(b"TAIL2"));
+    sb2.finish();
+
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf).await.unwrap();
+    assert_eq!(&buf[..], b"PEEK-TAIL1TAIL2");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn downconvert_stream_to_buffered() {
+    // Simulate Result::Stream -> buffer it
+    let sb = Arc::new(SharedBody::new(8));
+    let meta = FetchResultMeta {
+        final_url: "https://example.test/".parse().unwrap(),
+        status: 200,
+        status_text: "OK".into(),
+        headers: Default::default(),
+        content_length: None,
+        peek: Vec::new(),
+        has_body: true,
+    };
+
+    let peek = b"HEAD".to_vec();
+
+    // Tail in the background
+    let sbp = sb.clone();
+    tokio::spawn(async move {
+        sbp.push(Bytes::from_static(b"-BODY-1"));
+        sbp.push(Bytes::from_static(b"-BODY-2"));
+        sbp.finish();
+    });
+
+    // Use your helper (adjust path) to convert stream -> buffered
+    let res = gosub_engine::net::shared_body::stream_to_bytes(meta.clone(), peek, sb.clone()).await;
+
+    match res {
+        FetchResult::Buffered { meta: m2, body } => {
+            assert_eq!(m2.status, 200);
+            assert_eq!(&body[..], b"HEAD-BODY-1-BODY-2");
+        }
+        _ => panic!("expected buffered"),
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,3 @@
+mod spawn;
+
+pub use spawn::spawn_named;

--- a/src/util/spawn.rs
+++ b/src/util/spawn.rs
@@ -1,0 +1,14 @@
+use tokio::task::{self, JoinHandle};
+
+/// Spawns a name task on tokio runtime with the given name and future. Will return the join
+/// handle
+pub fn spawn_named<F, T>(name: &str, fut: F) -> JoinHandle<T>
+where
+    F: std::future::Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    task::Builder::new()
+        .name(name)
+        .spawn(fut)
+        .expect(format!("failed to spawn task {}", name).as_str())
+}


### PR DESCRIPTION
Instead of doing a very simple "reqwest" to fetch a resource, this system will deal with the complexity of fetching resources. Multiple tabs requesting the same resource, dealing with streams and buffered requests, dealing with timeouts, cancellations by the user etc.

This all resulted in a rather complex setup that needs a bit of documentation (hopefully will fix that fast enough).

This setup can function as a base system for the engine. I think it should work pretty well, but more tests and benchmarks are needed.